### PR TITLE
Add ModalWizard, MappingWizardBody and PlanWizardBody components

### DIFF
--- a/app/javascript/common/helpers.js
+++ b/app/javascript/common/helpers.js
@@ -1,14 +1,16 @@
 // todo: expose this from patternfly-react instead?
+export const getDisplayName = Component =>
+  Component.displayName || Component.name || 'Component';
+
+// TODO upgrade to latest patternfly-react after next release, these are exposed now:
 export const bindMethods = (context, methods) => {
   methods.forEach(method => {
     context[method] = context[method].bind(context);
   });
 };
-
 export const noop = Function.prototype;
-
-export const getDisplayName = Component =>
-  Component.displayName || Component.name || 'Component';
+export const selectKeys = (obj, keys, fn = val => val) =>
+  keys.reduce((values, key) => ({ ...values, [key]: fn(obj[key]) }), {});
 
 // https://github.com/yahoo/react-intl/wiki/Upgrade-Guide#flatten-messages-object
 export const flattenMessages = (nestedMessages, prefix = '') =>

--- a/app/javascript/common/helpers.js
+++ b/app/javascript/common/helpers.js
@@ -2,16 +2,6 @@
 export const getDisplayName = Component =>
   Component.displayName || Component.name || 'Component';
 
-// TODO upgrade to latest patternfly-react after next release, these are exposed now:
-export const bindMethods = (context, methods) => {
-  methods.forEach(method => {
-    context[method] = context[method].bind(context);
-  });
-};
-export const noop = Function.prototype;
-export const selectKeys = (obj, keys, fn = val => val) =>
-  keys.reduce((values, key) => ({ ...values, [key]: fn(obj[key]) }), {});
-
 // https://github.com/yahoo/react-intl/wiki/Upgrade-Guide#flatten-messages-object
 export const flattenMessages = (nestedMessages, prefix = '') =>
   Object.keys(nestedMessages).reduce((messages, key) => {

--- a/app/javascript/common/messages.js
+++ b/app/javascript/common/messages.js
@@ -9,11 +9,27 @@ export default {
       emptyPlanCardInfo: 'Create a migration plan to start migrating.',
       emptyPlanCardButton: 'Create Migration Plan'
     },
-    mappingWizard: {
-      title: 'Infrastructure Mapping Wizard',
+    wizard: {
       cancel: 'Cancel',
       back: 'Back',
-      next: 'Next'
+      next: 'Next',
+      close: 'Close'
+    },
+    mappingWizard: {
+      title: 'Infrastructure Mapping Wizard',
+      loadingTitle: 'Loading Infrastructure Mappings...',
+      loadingMessage: 'Just a sec.',
+      general: 'General',
+      clusters: 'Clusters',
+      datastores: 'Datastores',
+      networks: 'Networks',
+      results: 'Results'
+    },
+    planWizard: {
+      title: 'Migration Plan Wizard',
+      loadingTitle: 'Loading Clusters...',
+      loadingMessage: 'This may take a minute.',
+      vms: 'VMs'
     }
   }
 };

--- a/app/javascript/components/MappingWizard/MappingWizardBody.js
+++ b/app/javascript/components/MappingWizard/MappingWizardBody.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ModalWizard from '../ModalWizard';
+
+// TODO remove these, they are space fillers
+const t = str => (
+  <div align="center">
+    <h1>TODO: {str}!</h1>
+  </div>
+);
+const todo = str => (
+  <div>
+    {t(str)}
+    {t(str)}
+    {t(str)}
+    {t(str)}
+    {t(str)}
+  </div>
+);
+
+const MappingWizardBody = props => (
+  <ModalWizard.Body
+    {...props}
+    loadingTitle="planWizard.loadingTitle"
+    loadingMessage="planWizard.loadingMessage"
+    steps={[
+      {
+        title: 'mappingWizard.general',
+        render: () => todo('Name and Description Fields'),
+        onClick: () => console.log('on step 1 click')
+      },
+      {
+        title: 'mappingWizard.clusters',
+        render: () => todo('Cluster Mappings Form'),
+        onClick: () => console.log('on step 2 click')
+      },
+      {
+        title: 'mappingWizard.datastores',
+        render: () => todo('Datastore Mappings Form'),
+        onClick: () => console.log('on step 3 click')
+      },
+      {
+        title: 'mappingWizard.networks',
+        render: () => todo('Network Mappings Form'),
+        onClick: () => console.log('on step 4 click')
+      },
+      {
+        title: 'mappingWizard.results',
+        render: () => todo('Display Progress and Results'),
+        onClick: () => console.log('on step 5 click')
+      }
+    ]}
+  />
+);
+
+MappingWizardBody.propTypes = {
+  loaded: PropTypes.bool,
+  activeStepIndex: PropTypes.number,
+  activeStep: PropTypes.string
+};
+
+MappingWizardBody.defaultProps = {
+  loaded: false,
+  activeStepIndex: 0,
+  activeStep: '1'
+};
+
+export default MappingWizardBody;

--- a/app/javascript/components/MappingWizard/index.js
+++ b/app/javascript/components/MappingWizard/index.js
@@ -2,31 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
-import {
-  Button,
-  Icon,
-  EmptyState,
-  Modal,
-  Spinner,
-  Wizard
-} from 'patternfly-react';
+import { noop, selectKeys } from '../../common/helpers';
 import * as MappingWizardActions from '../../redux/actions/mappingWizard';
-import { noop } from '../../common/helpers';
-
-const loadingContents = () => (
-  <EmptyState>
-    <Spinner size="lg" className="blank-slate-pf-icon" loading />
-    <EmptyState.Action>
-      <h3>Loading Wizard</h3>
-    </EmptyState.Action>
-    <EmptyState.Action secondary>
-      <p>
-        Lorem ipsum dolor sit amet, porta at suspendisse ac, ut wisi vivamus,
-        lorem sociosqu eget nunc amet.{' '}
-      </p>
-    </EmptyState.Action>
-  </EmptyState>
-);
+import ModalWizard from '../ModalWizard';
+import MappingWizardBody from './MappingWizardBody';
 
 class MappingWizardContainer extends React.Component {
   componentDidMount() {
@@ -34,52 +13,28 @@ class MappingWizardContainer extends React.Component {
 
     fetchSourceClusters(url);
   }
-  render() {
-    const { showWizard, onHide, onExited, sourceClusters } = this.props;
 
-    console.log(sourceClusters);
+  render() {
+    const { sourceClusters } = this.props;
+    const loaded = sourceClusters && sourceClusters.length > 0;
+    const modalProps = selectKeys(this.props, [
+      'showWizard',
+      'onHide',
+      'onExited'
+    ]);
+
+    console.log('Source Clusters:', sourceClusters);
+    console.log('Loaded:', loaded);
 
     return (
-      <Modal
-        show={showWizard}
-        onHide={onHide}
-        onExited={onExited}
-        dialogClassName="modal-lg wizard-pf"
-      >
-        <Wizard>
-          <Modal.Header>
-            <button
-              className="close"
-              onClick={onHide}
-              aria-hidden="true"
-              aria-label="Close"
-            >
-              <Icon type="pf" name="close" />
-            </button>
-            <Modal.Title>
-              <FormattedMessage id="mappingWizard.title" />
-            </Modal.Title>
-          </Modal.Header>
-          <Modal.Body className="wizard-pf-body clearfix">
-            <Wizard.Row>
-              <Wizard.Main>{loadingContents()}</Wizard.Main>
-            </Wizard.Row>
-          </Modal.Body>
-          <Modal.Footer className="wizard-pf-footer">
-            <Button bsStyle="default" className="btn-cancel" onClick={onHide}>
-              <FormattedMessage id="mappingWizard.cancel" />
-            </Button>
-            <Button bsStyle="default" disabled>
-              <Icon type="fa" name="angle-left" />
-              <FormattedMessage id="mappingWizard.back" />
-            </Button>
-            <Button bsStyle="primary" disabled>
-              <FormattedMessage id="mappingWizard.next" />
-              <Icon type="fa" name="angle-right" />
-            </Button>
-          </Modal.Footer>
-        </Wizard>
-      </Modal>
+      <ModalWizard.StateProvider numSteps={5}>
+        <ModalWizard
+          {...modalProps}
+          title={<FormattedMessage id="mappingWizard.title" />}
+        >
+          <MappingWizardBody loaded={loaded} />
+        </ModalWizard>
+      </ModalWizard.StateProvider>
     );
   }
 }
@@ -92,9 +47,6 @@ MappingWizardContainer.propTypes = {
   sourceClusters: PropTypes.arrayOf(PropTypes.object)
 };
 MappingWizardContainer.defaultProps = {
-  onHide: noop,
-  onExited: noop,
-  showWizard: false,
   url: '',
   fetchSourceClusters: noop,
   sourceClusters: []

--- a/app/javascript/components/MappingWizard/index.js
+++ b/app/javascript/components/MappingWizard/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
-import { noop, selectKeys } from '../../common/helpers';
+import { noop, selectKeys } from 'patternfly-react';
 import * as MappingWizardActions from '../../redux/actions/mappingWizard';
 import ModalWizard from '../ModalWizard';
 import MappingWizardBody from './MappingWizardBody';
@@ -15,8 +15,7 @@ class MappingWizardContainer extends React.Component {
   }
 
   render() {
-    const { sourceClusters } = this.props;
-    const loaded = sourceClusters && sourceClusters.length > 0;
+    const { sourceClusters, isFetching } = this.props;
     const modalProps = selectKeys(this.props, [
       'showWizard',
       'onHide',
@@ -24,7 +23,6 @@ class MappingWizardContainer extends React.Component {
     ]);
 
     console.log('Source Clusters:', sourceClusters);
-    console.log('Loaded:', loaded);
 
     return (
       <ModalWizard.StateProvider numSteps={5}>
@@ -32,7 +30,7 @@ class MappingWizardContainer extends React.Component {
           {...modalProps}
           title={<FormattedMessage id="mappingWizard.title" />}
         >
-          <MappingWizardBody loaded={loaded} />
+          <MappingWizardBody loaded={!isFetching} />
         </ModalWizard>
       </ModalWizard.StateProvider>
     );
@@ -44,12 +42,14 @@ MappingWizardContainer.propTypes = {
   showWizard: PropTypes.bool,
   url: PropTypes.string,
   fetchSourceClusters: PropTypes.func,
-  sourceClusters: PropTypes.arrayOf(PropTypes.object)
+  sourceClusters: PropTypes.arrayOf(PropTypes.object),
+  isFetching: PropTypes.bool
 };
 MappingWizardContainer.defaultProps = {
   url: '',
   fetchSourceClusters: noop,
-  sourceClusters: []
+  sourceClusters: [],
+  isFetching: true
 };
 
 const mapStateToProps = (state, ownProps) => ({

--- a/app/javascript/components/ModalWizard/ModalWizard.js
+++ b/app/javascript/components/ModalWizard/ModalWizard.js
@@ -14,6 +14,7 @@ const ModalWizard = props => {
     activeStepIndex,
     activeStep,
     numSteps,
+    goToStep,
     children
   } = props;
   const onFirstStep = activeStepIndex === 0;
@@ -41,7 +42,8 @@ const ModalWizard = props => {
           {React.Children.map(children, child =>
             React.cloneElement(child, {
               activeStepIndex,
-              activeStep
+              activeStep,
+              goToStep
             })
           )}
         </Modal.Body>
@@ -77,6 +79,7 @@ ModalWizard.propTypes = {
   activeStepIndex: PropTypes.number,
   activeStep: PropTypes.string,
   numSteps: PropTypes.number,
+  goToStep: PropTypes.func,
   children: PropTypes.node
 };
 
@@ -90,6 +93,7 @@ ModalWizard.defaultProps = {
   activeStepIndex: 0,
   activeStep: '1',
   numSteps: 1,
+  goToStep: PropTypes.func,
   children: null
 };
 

--- a/app/javascript/components/ModalWizard/ModalWizard.js
+++ b/app/javascript/components/ModalWizard/ModalWizard.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Modal, Wizard, Icon, Button } from 'patternfly-react';
-import { noop } from '../../common/helpers';
+import { noop, Modal, Wizard, Icon, Button } from 'patternfly-react';
 
 const ModalWizard = props => {
   const {

--- a/app/javascript/components/ModalWizard/ModalWizard.js
+++ b/app/javascript/components/ModalWizard/ModalWizard.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Modal, Wizard, Icon, Button } from 'patternfly-react';
+import { noop } from '../../common/helpers';
+
+const ModalWizard = props => {
+  const {
+    title,
+    showWizard,
+    onHide,
+    onExited,
+    onBack,
+    onNext,
+    activeStepIndex,
+    activeStep,
+    numSteps,
+    children
+  } = props;
+  const onFirstStep = activeStepIndex === 0;
+  const onFinalStep = activeStepIndex === numSteps - 1;
+  return (
+    <Modal
+      show={showWizard}
+      onHide={onHide}
+      onExited={onExited}
+      dialogClassName="modal-lg wizard-pf"
+    >
+      <Wizard>
+        <Modal.Header>
+          <button
+            className="close"
+            onClick={onHide}
+            aria-hidden="true"
+            aria-label="Close"
+          >
+            <Icon type="pf" name="close" />
+          </button>
+          <Modal.Title>{title}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body className="wizard-pf-body clearfix">
+          {React.Children.map(children, child =>
+            React.cloneElement(child, {
+              activeStepIndex,
+              activeStep
+            })
+          )}
+        </Modal.Body>
+        <Modal.Footer className="wizard-pf-footer">
+          <Button bsStyle="default" className="btn-cancel" onClick={onHide}>
+            <FormattedMessage id="wizard.cancel" />
+          </Button>
+          <Button bsStyle="default" onClick={onBack} disabled={onFirstStep}>
+            <Icon type="fa" name="angle-left" />
+            <FormattedMessage id="wizard.back" />
+          </Button>
+          <Button bsStyle="primary" onClick={onFinalStep ? onHide : onNext}>
+            {onFinalStep ? (
+              <FormattedMessage id="wizard.close" />
+            ) : (
+              <FormattedMessage id="wizard.next" />
+            )}
+            <Icon type="fa" name="angle-right" />
+          </Button>
+        </Modal.Footer>
+      </Wizard>
+    </Modal>
+  );
+};
+
+ModalWizard.propTypes = {
+  showWizard: PropTypes.bool,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  onHide: PropTypes.func,
+  onExited: PropTypes.func,
+  onBack: PropTypes.func,
+  onNext: PropTypes.func,
+  activeStepIndex: PropTypes.number,
+  activeStep: PropTypes.string,
+  numSteps: PropTypes.number,
+  children: PropTypes.node
+};
+
+ModalWizard.defaultProps = {
+  showWizard: false,
+  title: '',
+  onHide: noop,
+  onExited: noop,
+  onBack: noop,
+  onNext: noop,
+  activeStepIndex: 0,
+  activeStep: '1',
+  numSteps: 1,
+  children: null
+};
+
+export default ModalWizard;

--- a/app/javascript/components/ModalWizard/ModalWizardBody.js
+++ b/app/javascript/components/ModalWizard/ModalWizardBody.js
@@ -10,8 +10,9 @@ class ModalWizardBody extends React.Component {
   }
 
   onStepClick(stepIndex) {
-    const { steps } = this.props;
+    const { steps, goToStep } = this.props;
     const step = steps[stepIndex];
+    goToStep(stepIndex);
     if (step && step.onClick) {
       step.onClick();
     }
@@ -100,6 +101,7 @@ ModalWizardBody.propTypes = {
   activeStepIndex: PropTypes.number,
   activeStep: PropTypes.string,
   onClick: PropTypes.func,
+  goToStep: PropTypes.func,
   intl: PropTypes.object.isRequired
 };
 
@@ -110,7 +112,8 @@ ModalWizardBody.defaultProps = {
   steps: [{ title: 'General', render: () => <p>General</p> }],
   activeStepIndex: 0,
   activeStep: '1',
-  onClick: noop
+  onClick: noop,
+  goToStep: noop
 };
 
 export default injectIntl(ModalWizardBody);

--- a/app/javascript/components/ModalWizard/ModalWizardBody.js
+++ b/app/javascript/components/ModalWizard/ModalWizardBody.js
@@ -1,0 +1,117 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, FormattedMessage } from 'react-intl';
+import { EmptyState, Spinner, Wizard } from 'patternfly-react';
+import { bindMethods, noop } from '../../common/helpers';
+
+class ModalWizardBody extends React.Component {
+  constructor() {
+    super();
+    bindMethods(this, ['onStepClick', 'stepProps', 'renderLoading']);
+  }
+
+  onStepClick(stepIndex) {
+    const { steps } = this.props;
+    const step = steps[stepIndex];
+    if (step && step.onClick) {
+      step.onClick();
+    }
+    console.log('on step index click: ', stepIndex);
+  }
+
+  stepProps(stepIndex, titleId) {
+    const { activeStep } = this.props;
+    const label = (stepIndex + 1).toString();
+    const title = this.props.intl.formatMessage({ id: titleId });
+    return {
+      key: `wizard-step-${title}`,
+      stepIndex,
+      label,
+      step: label,
+      title,
+      activeStep
+    };
+  }
+
+  renderLoading() {
+    const { loadingTitle, loadingMessage } = this.props;
+    return (
+      <Wizard.Row>
+        <Wizard.Main>
+          <EmptyState>
+            <Spinner size="lg" className="blank-slate-pf-icon" loading />
+            <EmptyState.Action>
+              <h3>
+                <FormattedMessage id={loadingTitle} />
+              </h3>
+            </EmptyState.Action>
+            <EmptyState.Action secondary>
+              <p>
+                <FormattedMessage id={loadingMessage} />
+              </p>
+            </EmptyState.Action>
+          </EmptyState>
+        </Wizard.Main>
+      </Wizard.Row>
+    );
+  }
+
+  render() {
+    const { loaded, steps, activeStepIndex } = this.props;
+    const step = steps[activeStepIndex];
+
+    if (!loaded) {
+      return this.renderLoading();
+    }
+
+    const renderedStep =
+      step && step.render && step.render(activeStepIndex, step.title);
+
+    return (
+      <React.Fragment>
+        <Wizard.Steps
+          steps={steps.map((stepObj, index) => (
+            <Wizard.Step
+              {...this.stepProps(index, stepObj.title)}
+              onClick={() => this.onStepClick(index)}
+            />
+          ))}
+        />
+        <Wizard.Row>
+          <Wizard.Main>
+            <Wizard.Contents>{renderedStep}</Wizard.Contents>
+          </Wizard.Main>
+        </Wizard.Row>
+      </React.Fragment>
+    );
+  }
+}
+
+ModalWizardBody.propTypes = {
+  loadingTitle: PropTypes.string,
+  loadingMessage: PropTypes.string,
+  loaded: PropTypes.bool,
+  steps: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      render: PropTypes.func,
+      onClick: PropTypes.func
+    })
+  ),
+  activeStepIndex: PropTypes.number,
+  activeStep: PropTypes.string,
+  onClick: PropTypes.func,
+  intl: PropTypes.object.isRequired
+};
+
+ModalWizardBody.defaultProps = {
+  loadingTitle: 'Loading Wizard...',
+  loadingMessage: 'Lorem ipsum dolor sit amet...',
+  loaded: false,
+  steps: [{ title: 'General', render: () => <p>General</p> }],
+  activeStepIndex: 0,
+  activeStep: '1',
+  onClick: noop
+};
+
+export default injectIntl(ModalWizardBody);

--- a/app/javascript/components/ModalWizard/ModalWizardBody.js
+++ b/app/javascript/components/ModalWizard/ModalWizardBody.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, FormattedMessage } from 'react-intl';
-import { EmptyState, Spinner, Wizard } from 'patternfly-react';
-import { bindMethods, noop } from '../../common/helpers';
+import { bindMethods, noop, EmptyState, Spinner, Wizard } from 'patternfly-react';
 
 class ModalWizardBody extends React.Component {
   constructor() {

--- a/app/javascript/components/ModalWizard/ModalWizardStateProvider.js
+++ b/app/javascript/components/ModalWizard/ModalWizardStateProvider.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { bindMethods } from '../../common/helpers';
+import { bindMethods } from 'patternfly-react';
 
 class ModalWizardStateProvider extends React.Component {
   constructor() {

--- a/app/javascript/components/ModalWizard/ModalWizardStateProvider.js
+++ b/app/javascript/components/ModalWizard/ModalWizardStateProvider.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { bindMethods } from '../../common/helpers';
+
+class ModalWizardStateProvider extends React.Component {
+  constructor() {
+    super();
+    this.state = { activeStepIndex: 0 };
+    bindMethods(this, ['prevStep', 'nextStep']);
+  }
+
+  prevStep() {
+    const { activeStepIndex } = this.state;
+    this.setState({ activeStepIndex: Math.max(activeStepIndex - 1, 0) });
+  }
+
+  nextStep() {
+    const { numSteps } = this.props;
+    const { activeStepIndex } = this.state;
+    this.setState({
+      activeStepIndex: Math.min(activeStepIndex + 1, numSteps - 1)
+    });
+  }
+
+  render() {
+    const { numSteps, children } = this.props;
+    const { activeStepIndex } = this.state;
+    const activeStep = (activeStepIndex + 1).toString();
+    return (
+      <React.Fragment>
+        {React.Children.map(children, child =>
+          React.cloneElement(child, {
+            numSteps,
+            activeStepIndex,
+            activeStep,
+            onBack: this.prevStep,
+            onNext: this.nextStep
+          })
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+ModalWizardStateProvider.propTypes = {
+  numSteps: PropTypes.number,
+  children: PropTypes.node
+};
+
+ModalWizardStateProvider.defaultProps = {
+  numSteps: 1,
+  children: null
+};
+
+export default ModalWizardStateProvider;

--- a/app/javascript/components/ModalWizard/ModalWizardStateProvider.js
+++ b/app/javascript/components/ModalWizard/ModalWizardStateProvider.js
@@ -6,7 +6,7 @@ class ModalWizardStateProvider extends React.Component {
   constructor() {
     super();
     this.state = { activeStepIndex: 0 };
-    bindMethods(this, ['prevStep', 'nextStep']);
+    bindMethods(this, ['prevStep', 'nextStep', 'goToStep']);
   }
 
   prevStep() {
@@ -22,6 +22,10 @@ class ModalWizardStateProvider extends React.Component {
     });
   }
 
+  goToStep(activeStepIndex) {
+    this.setState({ activeStepIndex });
+  }
+
   render() {
     const { numSteps, children } = this.props;
     const { activeStepIndex } = this.state;
@@ -34,7 +38,8 @@ class ModalWizardStateProvider extends React.Component {
             activeStepIndex,
             activeStep,
             onBack: this.prevStep,
-            onNext: this.nextStep
+            onNext: this.nextStep,
+            goToStep: this.goToStep,
           })
         )}
       </React.Fragment>

--- a/app/javascript/components/ModalWizard/index.js
+++ b/app/javascript/components/ModalWizard/index.js
@@ -2,7 +2,6 @@ import ModalWizard from './ModalWizard';
 import ModalWizardBody from './ModalWizardBody';
 import ModalWizardStateProvider from './ModalWizardStateProvider';
 
-// TODO maybe move these up to patternfly-react?
 ModalWizard.StateProvider = ModalWizardStateProvider;
 ModalWizard.Body = ModalWizardBody;
 

--- a/app/javascript/components/ModalWizard/index.js
+++ b/app/javascript/components/ModalWizard/index.js
@@ -1,0 +1,9 @@
+import ModalWizard from './ModalWizard';
+import ModalWizardBody from './ModalWizardBody';
+import ModalWizardStateProvider from './ModalWizardStateProvider';
+
+// TODO maybe move these up to patternfly-react?
+ModalWizard.StateProvider = ModalWizardStateProvider;
+ModalWizard.Body = ModalWizardBody;
+
+export default ModalWizard;

--- a/app/javascript/components/PlanWizard/PlanWizardBody.js
+++ b/app/javascript/components/PlanWizard/PlanWizardBody.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ModalWizard from '../ModalWizard';
+
+// TODO remove these, they are space fillers
+const t = str => (
+  <div align="center">
+    <h1>TODO: {str}!</h1>
+  </div>
+);
+const todo = str => (
+  <div>
+    {t(str)}
+    {t(str)}
+    {t(str)}
+    {t(str)}
+    {t(str)}
+  </div>
+);
+
+const PlanWizardBody = props => (
+  <ModalWizard.Body
+    {...props}
+    loadingTitle="mappingWizard.loadingTitle"
+    loadingMessage="mappingWizard.loadingMessage"
+    steps={[
+      {
+        title: 'mappingWizard.general',
+        render: () => todo('Name and Description Fields'),
+        onClick: () => console.log('on step 1 click')
+      },
+      {
+        title: 'planWizard.vms',
+        render: () => todo('VM CSV Upload Form'),
+        onClick: () => console.log('on step 2 click')
+      },
+      {
+        title: 'mappingWizard.results',
+        render: () => todo('Display Progress and Results'),
+        onClick: () => console.log('on step 3 click')
+      }
+    ]}
+  />
+);
+
+PlanWizardBody.propTypes = {
+  loaded: PropTypes.bool,
+  activeStepIndex: PropTypes.number,
+  activeStep: PropTypes.string
+};
+
+PlanWizardBody.defaultProps = {
+  loaded: false,
+  activeStepIndex: 0,
+  activeStep: '1'
+};
+
+export default PlanWizardBody;

--- a/app/javascript/components/PlanWizard/index.js
+++ b/app/javascript/components/PlanWizard/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
-import { noop, selectKeys } from '../../common/helpers';
+import { noop, selectKeys } from 'patternfly-react';
 import ModalWizard from '../ModalWizard';
 import PlanWizardBody from './PlanWizardBody';
 
@@ -19,6 +19,7 @@ class PlanWizardContainer extends React.Component {
   }
 
   render() {
+    console.log('planwizprops!!!!', this.props);
     const { loaded } = this.state;
     const modalProps = selectKeys(this.props, [
       'showWizard',

--- a/app/javascript/components/PlanWizard/index.js
+++ b/app/javascript/components/PlanWizard/index.js
@@ -9,18 +9,18 @@ import PlanWizardBody from './PlanWizardBody';
 class PlanWizardContainer extends React.Component {
   constructor() {
     super();
-    this.state = { loaded: false };
+    this.state = { isFetching: true };
   }
   componentDidMount() {
     const that = this;
     setTimeout(() => {
-      that.setState({ loaded: true }); // TODO replace me with a real API request
+      // TODO replace me with a real API request
+      that.setState({ isFetching: false });
     }, 1000);
   }
 
   render() {
-    console.log('planwizprops!!!!', this.props);
-    const { loaded } = this.state;
+    const { isFetching } = this.state;
     const modalProps = selectKeys(this.props, [
       'showWizard',
       'onHide',
@@ -32,7 +32,7 @@ class PlanWizardContainer extends React.Component {
           {...modalProps}
           title={<FormattedMessage id="planWizard.title" />}
         >
-          <PlanWizardBody loaded={loaded} />
+          <PlanWizardBody loaded={!isFetching} />
         </ModalWizard>
       </ModalWizard.StateProvider>
     );

--- a/app/javascript/components/PlanWizard/index.js
+++ b/app/javascript/components/PlanWizard/index.js
@@ -1,75 +1,43 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import {
-  Button,
-  EmptyState,
-  Icon,
-  Modal,
-  Spinner,
-  Wizard
-} from 'patternfly-react';
-import { noop } from '../../common/helpers';
-
-const loadingContents = () => (
-  <EmptyState>
-    <Spinner size="lg" className="blank-slate-pf-icon" loading />
-    <EmptyState.Action>
-      <h3>Loading Wizard</h3>
-    </EmptyState.Action>
-    <EmptyState.Action secondary>
-      <p>
-        Lorem ipsum dolor sit amet, porta at suspendisse ac, ut wisi vivamus,
-        lorem sociosqu eget nunc amet.{' '}
-      </p>
-    </EmptyState.Action>
-  </EmptyState>
-);
+import { FormattedMessage } from 'react-intl';
+import { noop, selectKeys } from '../../common/helpers';
+import ModalWizard from '../ModalWizard';
+import PlanWizardBody from './PlanWizardBody';
 
 class PlanWizardContainer extends React.Component {
-  render() {
-    const { showWizard, onHide, onExited } = this.props;
+  constructor() {
+    super();
+    this.state = { loaded: false };
+  }
+  componentDidMount() {
+    const that = this;
+    setTimeout(() => {
+      that.setState({ loaded: true }); // TODO replace me with a real API request
+    }, 1000);
+  }
 
+  render() {
+    const { loaded } = this.state;
+    const modalProps = selectKeys(this.props, [
+      'showWizard',
+      'onHide',
+      'onExited'
+    ]);
     return (
-      <Modal
-        show={showWizard}
-        onHide={onHide}
-        onExited={onExited}
-        dialogClassName="modal-lg wizard-pf"
-      >
-        <Wizard>
-          <Modal.Header>
-            <button
-              className="close"
-              onClick={onHide}
-              aria-hidden="true"
-              aria-label="Close"
-            >
-              <Icon type="pf" name="close" />
-            </button>
-            <Modal.Title>Infrastructure Mapping Wizard</Modal.Title>
-          </Modal.Header>
-          <Modal.Body className="wizard-pf-body clearfix">
-            <Wizard.Row>
-              <Wizard.Main>{loadingContents()}</Wizard.Main>
-            </Wizard.Row>
-          </Modal.Body>
-          <Modal.Footer className="wizard-pf-footer">
-            <Button bsStyle="default" className="btn-cancel" onClick={onHide}>
-              Cancel
-            </Button>
-            <Button bsStyle="default" disabled>
-              <Icon type="fa" name="angle-left" />Back
-            </Button>
-            <Button bsStyle="primary" disabled>
-              Next<Icon type="fa" name="angle-right" />
-            </Button>
-          </Modal.Footer>
-        </Wizard>
-      </Modal>
+      <ModalWizard.StateProvider numSteps={3}>
+        <ModalWizard
+          {...modalProps}
+          title={<FormattedMessage id="planWizard.title" />}
+        >
+          <PlanWizardBody loaded={loaded} />
+        </ModalWizard>
+      </ModalWizard.StateProvider>
     );
   }
 }
+
 PlanWizardContainer.propTypes = {
   onHide: PropTypes.func,
   onExited: PropTypes.func,

--- a/app/javascript/migration/scenes/Overview/__snapshots__/overview.test.js.snap
+++ b/app/javascript/migration/scenes/Overview/__snapshots__/overview.test.js.snap
@@ -9,9 +9,13 @@ exports[`Overview component renders the overview 1`] = `
     locale="en"
     messages={
       Object {
-        "mappingWizard.back": "Back",
-        "mappingWizard.cancel": "Cancel",
-        "mappingWizard.next": "Next",
+        "mappingWizard.clusters": "Clusters",
+        "mappingWizard.datastores": "Datastores",
+        "mappingWizard.general": "General",
+        "mappingWizard.loadingMessage": "Just a sec.",
+        "mappingWizard.loadingTitle": "Loading Infrastructure Mappings...",
+        "mappingWizard.networks": "Networks",
+        "mappingWizard.results": "Results",
         "mappingWizard.title": "Infrastructure Mapping Wizard",
         "overview.emptyMappingCardButton": "Create Infrastructure Mapping",
         "overview.emptyMappingCardInfo": "Create mapping to later be used by a migration plan.",
@@ -19,6 +23,14 @@ exports[`Overview component renders the overview 1`] = `
         "overview.emptyPlanCardButton": "Create Migration Plan",
         "overview.emptyPlanCardInfo": "Create a migration plan to start migrating.",
         "overview.emptyPlanCardTitle": "Migration Plans",
+        "planWizard.loadingMessage": "This may take a minute.",
+        "planWizard.loadingTitle": "Loading Clusters...",
+        "planWizard.title": "Migration Plan Wizard",
+        "planWizard.vms": "VMs",
+        "wizard.back": "Back",
+        "wizard.cancel": "Cancel",
+        "wizard.close": "Close",
+        "wizard.next": "Next",
       }
     }
   >

--- a/app/javascript/migration/scenes/Overview/index.js
+++ b/app/javascript/migration/scenes/Overview/index.js
@@ -2,8 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Equalizer from 'react-equalizer';
 import { FormattedMessage } from 'react-intl';
-import { Button, EmptyState, Grid } from 'patternfly-react';
-import { bindMethods } from '../../../common/helpers';
+import { bindMethods, Button, EmptyState, Grid } from 'patternfly-react';
 import componentRegistry from '../../../components/componentRegistry';
 
 class Overview extends React.Component {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cx": "^18.1.11",
     "intl": "~1.2.5",
     "patternfly": "^3.35.1",
-    "patternfly-react": "^1.4.0",
+    "patternfly-react": "^1.7.0",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-bootstrap": "^0.31.5",

--- a/test/migration/app/assets/javascripts/cable.js
+++ b/test/migration/app/assets/javascripts/cable.js
@@ -9,5 +9,4 @@
   this.App || (this.App = {});
 
   App.cable = ActionCable.createConsumer();
-
-}).call(this);
+}.call(this));


### PR DESCRIPTION
Includes i18n out of the box. Tried to break this down into logical components. I think maybe the `ModalWizard`, `ModalWizardBody` and `ModalWizardStateProvider` can be moved up to patternfly-react?