### PR TITLE
Menu items are added via plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,7 @@ The aim of this plugin is to provide UI infrastructure to ManageIQ for the V2V e
 
 You need to checkout manageiq, manageiq-ui-classic next to each other and setup the gem overrides.
 
-Uses the following branch of manageiq-ui-classic to add Migration to the navigation menu:
-
-```
-https://github.com/priley86/manageiq-ui-classic/tree/v2v
-```
-
-Make sure to add this `miq_v2v_ui` gem to your `bundler.d/Gemfile.dev.rb` in `manageiq`:
+Make sure to add this `miq_v2v_ui_plugin` gem to your Gemfile or bundler.d/ in `manageiq`:
 
 ```ruby
 gem 'miq_v2v_ui', :path => File.expand_path('../../miq_v2v_ui_plugin', __dir__)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The aim of this plugin is to provide UI infrastructure to ManageIQ for the V2V e
 
 You need to checkout manageiq, manageiq-ui-classic next to each other and setup the gem overrides.
 
-Make sure to add this `miq_v2v_ui_plugin` gem to your Gemfile or bundler.d/ in `manageiq`:
+Make sure to add this `miq_v2v_ui` gem to your `bundler.d/Gemfile.dev.rb` in `manageiq`:
 
 ```ruby
 gem 'miq_v2v_ui', :path => File.expand_path('../../miq_v2v_ui_plugin', __dir__)

--- a/lib/miq_v2v_ui/engine.rb
+++ b/lib/miq_v2v_ui/engine.rb
@@ -10,5 +10,14 @@ module MiqV2vUI
       app.config.assets.paths << root.join('assets', 'images').to_s
     end
 
+    initializer 'plugin' do
+      Menu::CustomLoader.register(
+        Menu::Section.new(:compute, N_("Compute"), 'pficon pficon-cpu', [
+          Menu::Section.new(:migration, N_("Migration"), 'fa fa-plus', [
+            Menu::Item.new('overview', N_('Overview'), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration')
+          ])
+        ])
+      )
+    end
   end
 end

--- a/lib/miq_v2v_ui/engine.rb
+++ b/lib/miq_v2v_ui/engine.rb
@@ -12,11 +12,10 @@ module MiqV2vUI
 
     initializer 'plugin' do
       Menu::CustomLoader.register(
-        Menu::Section.new(:compute, N_("Compute"), 'pficon pficon-cpu', [
-          Menu::Section.new(:migration, N_("Migration"), 'fa fa-plus', [
-            Menu::Item.new('overview', N_('Overview'), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration')
-          ])
-        ])
+        Menu::Section.new(:migration, N_("Migration"), 'fa fa-plus', [
+          Menu::Item.new('overview', N_('Overview'), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration'),
+          Menu::Item.new('infrastructure_mappings', N_('Infrastructure Mappings'), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration/infrastructure-mappings')
+        ], nil, nil, nil, nil, :compute),
       )
     end
   end


### PR DESCRIPTION
**Wait** for [this PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/3347) to be merged!

Moves definition of Menu items from `manageiq-ui-classic` to `miq_v2v_ui_plugin` as suggested [here](https://github.com/martinpovolny/miq_plugin_example/blob/master/lib/miq_plugin_example/engine.rb).
Update `README.md`. Special commit with menu items is no longer needed.

