### PR TITLE
Fix ModalWizard next button disabled state

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/ModalWizard/ModalWizard.js
+++ b/app/javascript/react/screens/App/Overview/components/ModalWizard/ModalWizard.js
@@ -4,11 +4,11 @@ import { noop, Modal, Wizard, Icon, Button } from 'patternfly-react';
 import { connect } from 'react-redux';
 
 const reduxFormMap = {
-  'Infrastructure Mapping Wizard': [
+  [__('Infrastructure Mapping Wizard')]: [
     'mappingWizardGeneralStep',
     'mappingWizardClustersStep'
   ],
-  'Migration Plan Wizard': []
+  [__('Migration Plan Wizard')]: []
 };
 
 const ModalWizard = props => {

--- a/app/javascript/react/screens/App/Overview/components/ModalWizard/ModalWizard.js
+++ b/app/javascript/react/screens/App/Overview/components/ModalWizard/ModalWizard.js
@@ -2,7 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { noop, Modal, Wizard, Icon, Button } from 'patternfly-react';
 import { connect } from 'react-redux';
-import { find } from 'lodash';
+
+const reduxFormMap = {
+  'Infrastructure Mapping Wizard': [
+    'mappingWizardGeneralStep',
+    'mappingWizardClustersStep'
+  ],
+  'Migration Plan Wizard': []
+};
 
 const ModalWizard = props => {
   const {
@@ -22,10 +29,11 @@ const ModalWizard = props => {
   const onFirstStep = activeStepIndex === 0;
   const onFinalStep = activeStepIndex === numSteps - 1;
 
-  const formHasErrors =
-    find(formContainer, form => form.syncErrors) !== undefined;
-
-  const disableNextStep = formHasErrors;
+  const currentReduxForm = reduxFormMap[title][activeStepIndex];
+  const disableNextStep =
+    formContainer &&
+    Object.prototype.hasOwnProperty.call(formContainer, currentReduxForm) &&
+    !!formContainer[currentReduxForm].syncErrors;
 
   return (
     <Modal

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'patternfly-react';
 import { Field, reduxForm } from 'redux-form';
+import { length } from 'redux-form-validators';
 
 import ClustersStepForm from './components/ClustersStepForm';
 
@@ -41,6 +42,7 @@ class MappingWizardClustersStep extends React.Component {
           removeTargetCluster={removeTargetCluster}
           addTargetCluster={addTargetCluster}
           addSourceClusters={addSourceClusters}
+          validate={[length({ min: 1 })]}
         />
       );
     }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "classnames": "^2.2.5",
     "cx": "^18.1.11",
     "intl": "~1.2.5",
-    "lodash": "^4.17.5",
     "patternfly": "^3.35.1",
     "patternfly-react": "^1.7.0",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
Currently, ModalWizard reports an error if _any_ form in the entire
wizard is invalid. This results in a bug where, if a user is on a step
with a form error, and then clicks the back button, the `next` button
becomes permanently disabled (even if the current form is valid)

To prevent this, we also check to make sure that we are on the proper
step before disabling the button.

Included in this PR
* Disable the next button on the MappingWizardClustersStep if there are
no mappings
* Fix the global error behavior
* Remove lodash as it is no longer being used

# Notes
1. Not sure if this will play nice with with i18n [reduxFormMap](https://github.com/priley86/miq_v2v_ui_plugin/pull/53/files#diff-efbb747e6ab39e19b2b58601cfbc901fR6)