### PR TITLE
Add `planWizardGeneralStep` in the reduxFormMap to fix Next button

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/ModalWizard/ModalWizard.js
+++ b/app/javascript/react/screens/App/Overview/components/ModalWizard/ModalWizard.js
@@ -8,7 +8,7 @@ const reduxFormMap = {
     'mappingWizardGeneralStep',
     'mappingWizardClustersStep'
   ],
-  [__('Migration Plan Wizard')]: []
+  [__('Migration Plan Wizard')]: ['planWizardGeneralStep']
 };
 
 const ModalWizard = props => {


### PR DESCRIPTION
Fixes `Next` button for Plan Wizard Step1