### PR TITLE
Disable Next button on datastores and networks steps when there are no mappings

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizard.scss
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizard.scss
@@ -7,6 +7,10 @@
   align-items: center;
 }
 
+.dual-pane-mapper-form.is-hidden {
+  opacity: 0;
+}
+
 // TreeView container styles
 .treeview-container {
   margin-top: 20px;

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
+import { length } from 'redux-form-validators';
 import { noop, bindMethods } from 'patternfly-react';
 import SourceClusterSelect from '../SourceClusterSelect/SourceClusterSelect';
 import DatastoresStepForm from './components/DatastoresStepForm';
@@ -97,18 +98,18 @@ class MappingWizardDatastoresStep extends React.Component {
           selectedCluster={selectedCluster}
           form={form}
         />
-        {selectedCluster && (
-          <Field
-            name="datastoresMappings"
-            component={DatastoresStepForm}
-            sourceDatastores={sourceDatastores}
-            targetDatastores={targetDatastores}
-            selectedClusterMapping={selectedClusterMapping}
-            resetState={this.resetState}
-            isFetchingSourceDatastores={isFetchingSourceDatastores}
-            isFetchingTargetDatastores={isFetchingTargetDatastores}
-          />
-        )}
+        <Field
+          name="datastoresMappings"
+          component={DatastoresStepForm}
+          sourceDatastores={sourceDatastores}
+          targetDatastores={targetDatastores}
+          selectedCluster={selectedCluster}
+          selectedClusterMapping={selectedClusterMapping}
+          resetState={this.resetState}
+          isFetchingSourceDatastores={isFetchingSourceDatastores}
+          isFetchingTargetDatastores={isFetchingTargetDatastores}
+          validate={length({ min: 1 })}
+        />
       </div>
     );
   }

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { bindMethods } from 'patternfly-react';
+import cx from 'classnames';
 
 import DualPaneMapper from '../../DualPaneMapper/DualPaneMapper';
 import DualPaneMapperList from '../../DualPaneMapper/DualPaneMapperList';
@@ -218,7 +219,8 @@ class DatastoresStepForm extends React.Component {
       targetDatastores,
       isFetchingSourceDatastores,
       isFetchingTargetDatastores,
-      input
+      input,
+      selectedCluster
     } = this.props;
     const {
       selectedSourceDatastores,
@@ -226,8 +228,12 @@ class DatastoresStepForm extends React.Component {
       selectedMapping
     } = this.state;
 
+    const classes = cx('dual-pane-mapper-form', {
+      'is-hidden': !selectedCluster
+    });
+
     return (
-      <div className="dual-pane-mapper-form">
+      <div className={classes}>
         <DualPaneMapper
           handleButtonClick={this.addDatastoreMapping}
           validMapping={
@@ -298,6 +304,7 @@ export default DatastoresStepForm;
 
 DatastoresStepForm.propTypes = {
   input: PropTypes.object,
+  selectedCluster: PropTypes.object,
   selectedClusterMapping: PropTypes.object,
   sourceDatastores: PropTypes.array,
   targetDatastores: PropTypes.array,

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { noop, bindMethods } from 'patternfly-react';
 import { Field, reduxForm } from 'redux-form';
-
+import { length } from 'redux-form-validators';
 import SourceClusterSelect from '../SourceClusterSelect/SourceClusterSelect';
 import NetworksStepForm from './components/NetworksStepForm';
 
@@ -82,18 +82,18 @@ class MappingWizardNetworksStep extends React.Component {
           selectedCluster={selectedCluster}
           form={form}
         />
-        {selectedCluster && (
-          <Field
-            name="networksMappings"
-            component={NetworksStepForm}
-            sourceNetworks={sourceNetworks}
-            targetNetworks={targetNetworks}
-            selectedClusterMapping={selectedClusterMapping}
-            isFetchingSourceNetworks={isFetchingSourceNetworks}
-            isFetchingTargetNetworks={isFetchingTargetNetworks}
-            resetState={this.resetState}
-          />
-        )}
+        <Field
+          name="networksMappings"
+          component={NetworksStepForm}
+          sourceNetworks={sourceNetworks}
+          targetNetworks={targetNetworks}
+          selectedCluster={selectedCluster}
+          selectedClusterMapping={selectedClusterMapping}
+          isFetchingSourceNetworks={isFetchingSourceNetworks}
+          isFetchingTargetNetworks={isFetchingTargetNetworks}
+          resetState={this.resetState}
+          validate={length({ min: 1 })}
+        />
       </div>
     );
   }

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { bindMethods } from 'patternfly-react';
+import cx from 'classnames';
 
 import DualPaneMapper from '../../DualPaneMapper/DualPaneMapper';
 import DualPaneMapperList from '../../DualPaneMapper/DualPaneMapperList';
@@ -242,7 +243,8 @@ class NetworksStepForm extends React.Component {
       targetNetworks,
       isFetchingSourceNetworks,
       isFetchingTargetNetworks,
-      input
+      input,
+      selectedCluster
     } = this.props;
     const {
       selectedSourceNetworks,
@@ -250,8 +252,12 @@ class NetworksStepForm extends React.Component {
       selectedMapping
     } = this.state;
 
+    const classes = cx('dual-pane-mapper-form', {
+      'is-hidden': !selectedCluster
+    });
+
     return (
-      <div className="dual-pane-mapper-form">
+      <div className={classes}>
         <DualPaneMapper
           handleButtonClick={this.addNetworkMapping}
           validMapping={
@@ -327,6 +333,7 @@ NetworksStepForm.propTypes = {
   targetNetworks: PropTypes.array,
   isFetchingSourceNetworks: PropTypes.bool,
   isFetchingTargetNetworks: PropTypes.bool,
+  selectedCluster: PropTypes.object,
   selectedClusterMapping: PropTypes.object,
   resetState: PropTypes.func
 };


### PR DESCRIPTION
* Uses redux-form-validators length helper to check that there is at
least one mapping in the array
* In order to leverage redux-form's validation capabilities, a Field
component must be present. So, switch from conditionally rendering
Field to hiding it when there is no selected source cluster