### PR TITLE
Persist DualPaneMapper and TreeView when there are mappings

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -18,14 +18,14 @@ class MappingWizardDatastoresStep extends React.Component {
   }
 
   componentWillMount() {
-    const { clusterMappings } = this.props;
+    const { clusterMappings, pristine } = this.props;
 
     const sourceClusters = clusterMappings.reduce(
       (clusters, clusterMapping) => clusters.concat(clusterMapping.nodes),
       []
     );
 
-    if (sourceClusters.length === 1) {
+    if (sourceClusters.length === 1 || !pristine) {
       this.selectSourceCluster(sourceClusters[0].id);
     }
   }
@@ -125,7 +125,8 @@ MappingWizardDatastoresStep.propTypes = {
   isRejectedSourceDatastores: PropTypes.bool,
   isFetchingTargetDatastores: PropTypes.bool,
   isRejectedTargetDatastores: PropTypes.bool,
-  form: PropTypes.string
+  form: PropTypes.string,
+  pristine: PropTypes.bool
 };
 MappingWizardDatastoresStep.defaultProps = {
   clusterMappings: [],
@@ -138,7 +139,8 @@ MappingWizardDatastoresStep.defaultProps = {
   isRejectedSourceDatastores: false,
   isFetchingTargetDatastores: false,
   isRejectedTargetDatastores: false,
-  form: ''
+  form: '',
+  pristine: true
 };
 
 export default reduxForm({

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
@@ -18,6 +18,19 @@ class MappingWizardNetworksStep extends React.Component {
     bindMethods(this, ['selectSourceCluster', 'resetState']);
   }
 
+  componentWillMount() {
+    const { clusterMappings, pristine } = this.props;
+
+    const sourceClusters = clusterMappings.reduce(
+      (clusters, clusterMapping) => clusters.concat(clusterMapping.nodes),
+      []
+    );
+
+    if (sourceClusters.length === 1 || !pristine) {
+      this.selectSourceCluster(sourceClusters[0].id);
+    }
+  }
+
   componentDidMount() {}
 
   selectSourceCluster(sourceClusterId) {
@@ -110,7 +123,8 @@ MappingWizardNetworksStep.propTypes = {
   isRejectedSourceNetworks: PropTypes.bool,
   isFetchingTargetNetworks: PropTypes.bool,
   isRejectedTargetNetworks: PropTypes.bool,
-  form: PropTypes.string
+  form: PropTypes.string,
+  pristine: PropTypes.bool
 };
 MappingWizardNetworksStep.defaultProps = {
   clusterMappings: [],
@@ -123,7 +137,8 @@ MappingWizardNetworksStep.defaultProps = {
   isRejectedSourceNetworks: false,
   isFetchingTargetNetworks: false,
   isRejectedTargetNetworks: false,
-  form: ''
+  form: '',
+  pristine: true
 };
 
 export default reduxForm({


### PR DESCRIPTION
* A redux-form decorated component is passed a "pristine" prop. This
is a boolean value that indicates whether the form data has changed
from its initialized values
* Also included: If there is only one source cluster being mapped from
step-2, auto-select it when entering the datastores step
* Handles both the datastores and networks steps