### PR TITLE
Persist CSV rows as objects with named fields instead of arrays

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardCSVStep/CSVDropzoneField.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardCSVStep/CSVDropzoneField.js
@@ -11,8 +11,6 @@ import {
 } from 'patternfly-react';
 import Dropzone from 'react-dropzone';
 
-// TODO __('i18n')
-
 // Unfortunately, this is the recommended way to trigger the file dialog programmatically.
 // https://github.com/react-dropzone/react-dropzone/tree/master/examples/File%20Dialog
 let dropzoneRef;
@@ -31,10 +29,13 @@ class CSVDropzoneField extends React.Component {
         reader.onload = () => {
           csv.parse(reader.result, (err, csvRows) => {
             const rowObjects = csvRows.map(row =>
-              columnNames.reduce((rowObject, key, index) => ({
-                ...rowObject,
-                [key]: row[index]
-              }), {})
+              columnNames.reduce(
+                (rowObject, key, index) => ({
+                  ...rowObject,
+                  [key]: row[index]
+                }),
+                {}
+              )
             );
             input.onChange(rowObjects);
           });
@@ -78,8 +79,12 @@ class CSVDropzoneField extends React.Component {
             <ListView.Item
               description={vm.name || ''}
               additionalInfo={[
-                <ListView.InfoItem>{vm.path}</ListView.InfoItem>,
-                <ListView.InfoItem>{vm.ip}</ListView.InfoItem>
+                <ListView.InfoItem>
+                  {`${__('Provider:')} ${vm.provider || ''}`}
+                </ListView.InfoItem>,
+                <ListView.InfoItem>
+                  {`${__('Reference:')} ${vm.reference || ''}`}
+                </ListView.InfoItem>
               ]}
             />
           ))}

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardCSVStep/PlanWizardCSVStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardCSVStep/PlanWizardCSVStep.js
@@ -9,7 +9,7 @@ const PlanWizardCSVStep = () => (
     <Field
       name="csvRows"
       component={CSVDropzoneField}
-      columnNames={['id', 'name', 'path', 'ip', 'TODO']} // TODO
+      columnNames={['name', 'provider', 'reference']}
       validate={[
         length({ min: 1, msg: __('At least one VM needs to be selected') })
       ]}

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardCSVStep/PlanWizardCSVStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardCSVStep/PlanWizardCSVStep.js
@@ -9,6 +9,7 @@ const PlanWizardCSVStep = () => (
     <Field
       name="csvRows"
       component={CSVDropzoneField}
+      columnNames={['id', 'name', 'path', 'ip', 'TODO']} // TODO
       validate={[
         length({ min: 1, msg: __('At least one VM needs to be selected') })
       ]}


### PR DESCRIPTION
Provides a single source of truth (the `columnNames` prop) for the format of the CSV files, taking the burden of that assumption away from the redux code. This way we can continue to merge the rest of our wizard code, and only have to come back and change `columnNames` when we know the final format of the CSV.