### PR TITLE
Clear any selected datastores/networks when selecting a different source cluster

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm.js
@@ -201,7 +201,9 @@ class ClustersStepForm extends React.Component {
               ))}
               <DualPaneMapperCount
                 selectedItems={selectedSourceClusters.length}
-                totalItems={sourceClusters.length}
+                totalItems={
+                  sourceClustersFilter(sourceClusters, input.value).length
+                }
               />
             </DualPaneMapperList>
           )}

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm.js
@@ -31,6 +31,18 @@ class DatastoresStepForm extends React.Component {
     ]);
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (
+      this.props.selectedCluster &&
+      nextProps.selectedCluster.id !== this.props.selectedCluster.id
+    ) {
+      this.setState(() => ({
+        selectedSourceDatastores: [],
+        selectedTargetDatastore: null
+      }));
+    }
+  }
+
   selectSourceDatastore(sourceDatastore) {
     this.setState(prevState => {
       const isAlreadySelected = prevState.selectedSourceDatastores.some(

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm.js
@@ -31,6 +31,18 @@ class NetworksStepForm extends React.Component {
     ]);
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (
+      this.props.selectedCluster &&
+      nextProps.selectedCluster.id !== this.props.selectedCluster.id
+    ) {
+      this.setState(() => ({
+        selectedSourceNetworks: [],
+        selectedTargetNetwork: null
+      }));
+    }
+  }
+
   selectSourceNetwork(sourceNetwork) {
     this.setState(prevState => {
       const isAlreadySelected = prevState.selectedSourceNetworks.some(


### PR DESCRIPTION
When changing source clusters using the dropdown on either the
datastores or networks step, clear currently selected items.

## Also included
Small adjustment to fix the DualPaneCounter on the clusters step (step-2).  We need to filter the source clusters in order to properly calculate the remaining number

## Notes
This fixes a bug on both the datastores and networks step where the selected source and target datastores/networks were unintentionally being persisted when changing source clusters (using the dropdown)

To reproduce bug:
1. In the clusters step of the mapping wizard (step-2) map at least two source clusters
2. On the datastores step (step-3) select a source cluster from the dropdown
3. Select source datastores and a target datastore
4. _Without_ adding the mapping, use the dropdown to select the other source cluster
5. Notice that the `Add Mapping` button is still enabled, despite nothing appearing to be selected in the DualPaneMapper
6. If you click `Add Mapping`, it will add a mapping using the previously selected items
7. Same behavior for networks step (step-4)