### PR TITLE
base.scss - fix import to match the actual filename

### DIFF
--- a/app/assets/stylesheets/miq_v2v_ui/base.scss
+++ b/app/assets/stylesheets/miq_v2v_ui/base.scss
@@ -1,1 +1,1 @@
-@import '../../../javascript/react/App.scss';
+@import '../../../javascript/react/app.scss';


### PR DESCRIPTION
`App` vs `app` is a significant difference, except on Macs.

Fixes:

```
F, [2018-03-01T13:34:52.251039 #16686] FATAL -- : ActionView::Template::Error (File to import not found or unreadable: ../../../javascript/react/App.scss.
Load paths:
...
F, [2018-03-01T13:34:52.251167 #16686] FATAL -- :      8:     %meta{"http-equiv" => "Pragma", :content => "must-revalidate"}
     9:     %meta{"http-equiv" => "cache-control", :content => "no-cache, no-store"}
    10:
    11:     = favicon_link_tag
    12:     = stylesheet_link_tag 'application'
    13:     = render :partial => "stylesheets/template50"
    14:     = javascript_include_tag 'application'
F, [2018-03-01T13:34:52.251206 #16686] FATAL -- :
F, [2018-03-01T13:34:52.251248 #16686] FATAL -- : /home/himdel/miq_v2v_ui_plugin/app/assets/stylesheets/miq_v2v_ui/base.scss:1
sass (3.4.25) lib/sass/tree/import_node.rb:67:in `rescue in import'
sass (3.4.25) lib/sass/tree/import_node.rb:44:in `import'
sass (3.4.25) lib/sass/tree/import_node.rb:28:in `imported_file'
sass (3.4.25) lib/sass/tree/import_node.rb:37:in `css_import?'
...
```