### PR TITLE
Fix broken menu styling by removing MigrationHelper

### DIFF
--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -2,4 +2,6 @@
 # and to handle the initial routing endpoint.
 class MigrationController < ApplicationController
   def index; end
+
+  menu_section :migration
 end

--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -1,7 +1,15 @@
 # Migration controller - mostly service to initialize the react top level component
 # and to handle the initial routing endpoint.
 class MigrationController < ApplicationController
-  def index; end
+  def index
+    # this sets the active menu item, must match the item name in lib/miq_v2v_ui/engine.rb
+    @layout = case params[:page]
+              when 'infrastructure-mappings'
+                'infrastructure_mappings'
+              else
+                'overview'
+              end
+  end
 
   menu_section :migration
 end

--- a/app/helpers/migration_helper.rb
+++ b/app/helpers/migration_helper.rb
@@ -1,9 +1,0 @@
-module MigrationHelper
-  def section_nav_class(section = 'active')
-    section
-  end
-
-  def item_nav_class(item = 'active')
-    item
-  end
-end


### PR DESCRIPTION
MigrationHelper only overrode 2 ui-classic methods: `section_nav_class` and `item_nav_class`.

Those methods are supposed to get a menu item/section and return the right extra css classes.

What they did instead was to return the whole item/section, leading to a problem where the whole item/section was serialized in the classname (causing the menu `li` `class` attribute to contain `pficon` for items which used a pficon icon, leading to the wrong font being used).

Just removing, clearly the override does more harm than good :).

EDIT: except it turns out `controller.menu_section_id` can crash if the controller doesn't have any specified menu section - added `menu_section` to `MigrationController` :)