### PR TITLE
Fix top nav for mapping wizard

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/ModalWizard/ModalWizardBody.js
+++ b/app/javascript/react/screens/App/Overview/components/ModalWizard/ModalWizardBody.js
@@ -17,9 +17,9 @@ class ModalWizardBody extends React.Component {
     bindMethods(this, ['onStepClick', 'stepProps', 'renderLoading']);
   }
 
-  onStepClick(stepIndex) {
+  onStepClick(stepIndex, disabled) {
     const { steps, goToStep, disableNextStep } = this.props;
-    if (disableNextStep) return;
+    if (disableNextStep || disabled) return;
     const step = steps[stepIndex];
     goToStep(stepIndex);
     if (step && step.onClick) {
@@ -76,7 +76,8 @@ class ModalWizardBody extends React.Component {
           steps={steps.map((stepObj, index) => (
             <Wizard.Step
               {...this.stepProps(index, stepObj.title)}
-              onClick={() => this.onStepClick(index)}
+              onClick={() => this.onStepClick(index, stepObj.disabled)}
+              className={stepObj.disabled && 'is-disabled'}
             />
           ))}
         />

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizard.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizard.js
@@ -126,8 +126,18 @@ class MappingWizard extends React.Component {
 
   goToStep(activeStepIndex) {
     const { activeStepIndex: currentStep } = this.state;
+    const targetStepProp = mappingWizardSteps[activeStepIndex];
+    const targetStepForm = this.props[targetStepProp];
 
-    if (currentStep !== 4) {
+    if (activeStepIndex === 4) {
+      this.setState(prevState => ({
+        activeStepIndex: prevState.activeStepIndex
+      }));
+    } else if (currentStep === 2 && activeStepIndex === 3) {
+      this.nextStep();
+    } else if (currentStep < activeStepIndex && targetStepForm.values) {
+      this.setState(() => ({ activeStepIndex }));
+    } else if (currentStep !== 4) {
       this.setState(() => ({ activeStepIndex }));
     }
   }

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizard.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizard.js
@@ -126,18 +126,10 @@ class MappingWizard extends React.Component {
 
   goToStep(activeStepIndex) {
     const { activeStepIndex: currentStep } = this.state;
-    const targetStepProp = mappingWizardSteps[activeStepIndex];
-    const targetStepForm = this.props[targetStepProp];
 
-    if (activeStepIndex === 4) {
-      this.setState(prevState => ({
-        activeStepIndex: prevState.activeStepIndex
-      }));
-    } else if (currentStep === 2 && activeStepIndex === 3) {
+    if (currentStep === 2 && activeStepIndex === 3) {
       this.nextStep();
-    } else if (currentStep < activeStepIndex && targetStepForm.values) {
-      this.setState(() => ({ activeStepIndex }));
-    } else if (currentStep !== 4) {
+    } else {
       this.setState(() => ({ activeStepIndex }));
     }
   }
@@ -149,7 +141,11 @@ class MappingWizard extends React.Component {
       mappingWizardExitedAction,
       hideWarningModalAction,
       warningModalVisible,
-      sourceClustersWithoutMappings
+      sourceClustersWithoutMappings,
+      mappingWizardGeneralStep,
+      mappingWizardClustersStep,
+      mappingWizardDatastoresStep,
+      mappingWizardNetworksStep
     } = this.props;
 
     const { activeStepIndex, transformationsBody } = this.state;
@@ -188,6 +184,10 @@ class MappingWizard extends React.Component {
               goToStep={this.goToStep}
               disableNextStep={disableNextStep}
               transformationsBody={transformationsBody}
+              mappingWizardGeneralStep={mappingWizardGeneralStep}
+              mappingWizardClustersStep={mappingWizardClustersStep}
+              mappingWizardDatastoresStep={mappingWizardDatastoresStep}
+              mappingWizardNetworksStep={mappingWizardNetworksStep}
             />
           </Modal.Body>
           <Modal.Footer className="wizard-pf-footer">

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizard.scss
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizard.scss
@@ -41,3 +41,7 @@
 .wizard-pf-main .blank-slate-pf {
   padding: 30px;
 }
+
+.wizard-pf-step.is-disabled .wizard-pf-step-number {
+  cursor: not-allowed;
+}

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardBody.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardBody.js
@@ -35,27 +35,32 @@ class MappingWizardBody extends React.Component {
           {
             title: __('General'),
             render: () => <MappingWizardGeneralStep />,
-            onClick: () => console.log('on step 1 click')
+            onClick: () => console.log('on step 1 click'),
+            disabled: !this.props.mappingWizardGeneralStep.values
           },
           {
             title: __('Clusters'),
             render: () => this.mappingWizardClustersStepContainer,
-            onClick: () => console.log('on step 2 click')
+            onClick: () => console.log('on step 2 click'),
+            disabled: !this.props.mappingWizardClustersStep.values
           },
           {
             title: __('Datastores'),
             render: () => this.mappingWizardDatastoresStepContainer,
-            onClick: () => console.log('on step 3 click')
+            onClick: () => console.log('on step 3 click'),
+            disabled: !this.props.mappingWizardDatastoresStep.values
           },
           {
             title: __('Networks'),
             render: () => this.mappingWizardNetworksStepContainer,
-            onClick: () => console.log('on step 4 click')
+            onClick: () => console.log('on step 4 click'),
+            disabled: !this.props.mappingWizardNetworksStep.values
           },
           {
             title: __('Results'),
             render: () => this.mappingWizardResultsStepContainer,
-            onClick: () => console.log('on step 5 click')
+            onClick: () => console.log('on step 5 click'),
+            disabled: true
           }
         ]}
       />
@@ -69,7 +74,11 @@ MappingWizardBody.propTypes = {
   activeStep: PropTypes.string,
   goToStep: PropTypes.func,
   disableNextStep: PropTypes.bool,
-  transformationsBody: PropTypes.object
+  transformationsBody: PropTypes.object,
+  mappingWizardGeneralStep: PropTypes.object,
+  mappingWizardClustersStep: PropTypes.object,
+  mappingWizardDatastoresStep: PropTypes.object,
+  mappingWizardNetworksStep: PropTypes.object
 };
 
 MappingWizardBody.defaultProps = {
@@ -78,7 +87,11 @@ MappingWizardBody.defaultProps = {
   activeStep: '1',
   goToStep: noop,
   disableNextStep: true,
-  transformationsBody: {}
+  transformationsBody: {},
+  mappingWizardGeneralStep: {},
+  mappingWizardClustersStep: {},
+  mappingWizardDatastoresStep: {},
+  mappingWizardNetworksStep: {}
 };
 
 export default MappingWizardBody;

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/__tests__/__snapshots__/MappingWizard.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/__tests__/__snapshots__/MappingWizard.test.js.snap
@@ -66,6 +66,10 @@ exports[`MappingWizard component renders the mapping wizard 1`] = `
         disableNextStep={false}
         goToStep={[Function]}
         loaded={true}
+        mappingWizardClustersStep={Object {}}
+        mappingWizardDatastoresStep={Object {}}
+        mappingWizardGeneralStep={Object {}}
+        mappingWizardNetworksStep={Object {}}
         transformationsBody={Object {}}
       />
     </ModalBody>


### PR DESCRIPTION
Only allow users to use Wizard.Step to navigate
to steps they have already visited at least once

* We need to prevent users from skipping past the clusters step (step-2)
because if there are no cluster mappings, the dropdown selects in the
datastores (step-3) and networks (step-4) steps will not populate.
* When a redux-form element is mounted, the form's value key is
initialized with an empty object. So a Wizard.Step is disabled until
the user has visited that step at least once
* This forces the user to go through the mapping wizard sequentially
once, and afterwards, frees them to use the top nav to jump between all
of the steps, except step-5
* Entering step-5 automatically submits the infrastructure mapping, so
that Wizard.Step is permanently disabled. The user must hit the Create
button in step 4
* Changes the cursor to not-allowed when hovering over a disabled
Wizard.Step

## Note
The changes made to `ModalWizardBody` will not affect the PlanWizard