### PR TITLE
fix step 5 close logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ The aim of this plugin is to provide UI infrastructure to ManageIQ for the V2V e
 
 ## TODO
 
-* Add Redux Support
-* .. and much more :-)
+* MIGRATE SOME VMs!!!
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The aim of this plugin is to provide UI infrastructure to ManageIQ for the V2V e
 
 ## TODO
 
+* Integrate all APIs
 * MIGRATE SOME VMs!!!
 
 ## Usage

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -39,11 +39,12 @@ class Overview extends React.Component {
       fetchTransformationMappingsUrl,
       fetchTransformationMappingsAction,
       planWizardId,
-      continueToPlanAction
+      continueToPlanAction,
+      shouldReloadMappings
     } = this.props;
     if (
-      isContinuingToPlan !== nextProps.isContinuingToPlan &&
-      nextProps.isContinuingToPlan
+      shouldReloadMappings !== nextProps.shouldReloadMappings &&
+      nextProps.shouldReloadMappings
     ) {
       // refetech our mappings so that plan wizard has this newly created mapping
       fetchTransformationMappingsAction(fetchTransformationMappingsUrl);
@@ -136,6 +137,7 @@ Overview.propTypes = {
   isRejectedTransformationMappings: PropTypes.bool,
   isContinuingToPlan: PropTypes.bool,
   planWizardId: PropTypes.string,
-  continueToPlanAction: PropTypes.func
+  continueToPlanAction: PropTypes.func,
+  shouldReloadMappings: PropTypes.bool
 };
 export default Overview;

--- a/app/javascript/react/screens/App/Overview/OverviewReducer.js
+++ b/app/javascript/react/screens/App/Overview/OverviewReducer.js
@@ -20,7 +20,8 @@ const initialState = Immutable({
   transformationMappings: [],
   isRejectedTransformationMappings: false,
   isFetchingTransformationMappings: false,
-  isContinuingToPlan: false
+  isContinuingToPlan: false,
+  shouldReloadMappings: false
 });
 
 export default (state = initialState, action) => {
@@ -30,8 +31,15 @@ export default (state = initialState, action) => {
         mappingWizardVisible: true,
         hideMappingWizard: false
       });
-    case HIDE_MAPPING_WIZARD:
-      return state.set('hideMappingWizard', true);
+    case HIDE_MAPPING_WIZARD: {
+      const { payload } = action;
+      return state
+        .set('hideMappingWizard', true)
+        .set(
+          'shouldReloadMappings',
+          (payload && payload.shouldReloadMappings) || false
+        );
+    }
     case MAPPING_WIZARD_EXITED:
       return state.set('mappingWizardVisible', false);
     case SHOW_PLAN_WIZARD:
@@ -53,6 +61,7 @@ export default (state = initialState, action) => {
           .set('transformationMappings', action.payload.data.resources)
           .set('isRejectedTransformationMappings', false)
           .set('isFetchingTransformationMappings', false)
+          .set('shouldReloadMappings', false)
           .set('isContinuingToPlan', false);
       }
       return state
@@ -67,6 +76,7 @@ export default (state = initialState, action) => {
     case CONTINUE_TO_PLAN:
       return state
         .set('isContinuingToPlan', true)
+        .set('shouldReloadMappings', true)
         .set('planWizardId', action.payload.id);
     default:
       return state;

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizard.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizard.js
@@ -160,7 +160,9 @@ class MappingWizard extends React.Component {
     return (
       <Modal
         show={!hideMappingWizard}
-        onHide={hideMappingWizardAction}
+        onHide={() => {
+          hideMappingWizardAction(onFinalStep);
+        }}
         onExited={mappingWizardExitedAction}
         dialogClassName="modal-lg wizard-pf"
       >
@@ -168,7 +170,9 @@ class MappingWizard extends React.Component {
           <Modal.Header>
             <button
               className="close"
-              onClick={hideMappingWizardAction}
+              onClick={() => {
+                hideMappingWizardAction(onFinalStep);
+              }}
               aria-hidden="true"
               aria-label="Close"
             >
@@ -194,7 +198,9 @@ class MappingWizard extends React.Component {
             <Button
               bsStyle="default"
               className="btn-cancel"
-              onClick={hideMappingWizardAction}
+              onClick={() => {
+                hideMappingWizardAction(onFinalStep);
+              }}
               disabled={onFinalStep}
             >
               {__('Cancel')}
@@ -210,7 +216,11 @@ class MappingWizard extends React.Component {
             </Button>
             <Button
               bsStyle="primary"
-              onClick={onFinalStep ? hideMappingWizardAction : this.nextStep}
+              onClick={
+                onFinalStep
+                  ? () => hideMappingWizardAction(onFinalStep)
+                  : this.nextStep
+              }
               disabled={disableNextStep}
             >
               {onFinalStep

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardActions.js
@@ -10,9 +10,10 @@ import {
   V2V_HIDE_WARNING_MODAL
 } from './MappingWizardConstants';
 
-export const hideMappingWizardAction = () => dispatch => {
+export const hideMappingWizardAction = shouldReloadMappings => dispatch => {
   dispatch({
-    type: HIDE_MAPPING_WIZARD
+    type: HIDE_MAPPING_WIZARD,
+    payload: { shouldReloadMappings }
   });
 };
 

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/__tests__/__snapshots__/MappingWizard.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/__tests__/__snapshots__/MappingWizard.test.js.snap
@@ -23,7 +23,7 @@ exports[`MappingWizard component renders the mapping wizard 1`] = `
     }
   }
   onExited={[MockFunction]}
-  onHide={[MockFunction]}
+  onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
   show={true}
@@ -41,7 +41,7 @@ exports[`MappingWizard component renders the mapping wizard 1`] = `
         aria-hidden="true"
         aria-label="Close"
         className="close"
-        onClick={[MockFunction]}
+        onClick={[Function]}
       >
         <Icon
           name="close"
@@ -85,7 +85,7 @@ exports[`MappingWizard component renders the mapping wizard 1`] = `
         bsStyle="default"
         className="btn-cancel"
         disabled={false}
-        onClick={[MockFunction]}
+        onClick={[Function]}
       >
         Cancel
       </Button>

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/helpers.js
@@ -7,7 +7,7 @@ export const createMigrationPlans = (
   const infrastructureMapping =
     planWizardGeneralStep.values.infrastructure_mapping;
   const vms = planWizardCSVStep.values.csvRows.map(value =>
-    value['reference'].trim()
+    value.reference.trim()
   );
 
   return {


### PR DESCRIPTION
Fixes an issue where we were not reloading mappings after reaching Step 5 and the Mapping Wizard was being "Closed" instead of "Continued".

* Now we can pass a variable `shouldReloadMappings` as the HIDE_MAPPING_WIZARD action payload indicating that we reached step 5 and we should reload mappings
* The previous bug fixed here was that you would not see the newly created mapping in the list of mappings on the Plan Wizard if the user Closed at Step 5 instead of Continued. This fixes that and ensures that we reload mappings every time we reach Step 5 and the user Closes/Continues.

* tested that mappings do not reload after closing steps 1-4
* tested that mappings will reload after "closing" step 5 and dropdown in Plan populated new item
* tested that mappings will reload after "continuing" and new item is selected in Plan

Woohoo!!  🐛 🔨  (hammered bug.... poor little guy...)

Closes #95 