### PR TITLE
introduce globalMock setting and polling for active/completed migrations

### DIFF
--- a/app/javascript/common/API.js
+++ b/app/javascript/common/API.js
@@ -37,3 +37,5 @@ export default {
     });
   }
 };
+
+export const globalMockMode = false;

--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -12,8 +12,9 @@ import LongDateTime from './dates/LongDateTime';
 import RelativeDateTime from './dates/RelativeDateTime';
 import ShortDateTime from './dates/ShortDateTime';
 import MiqV2vUi from '../react';
+import { globalMockMode } from '../common/API';
 
-const mockMode = false;
+const mockMode = globalMockMode;
 
 export const coreComponents = [
   {

--- a/app/javascript/react/screens/App/Overview/OverviewActions.js
+++ b/app/javascript/react/screens/App/Overview/OverviewActions.js
@@ -1,5 +1,5 @@
 import URI from 'urijs';
-import API from '../../../../common/API';
+import API, { globalMockMode } from '../../../../common/API';
 
 import {
   SHOW_MAPPING_WIZARD,
@@ -10,7 +10,7 @@ import {
 
 import { requestTransformationMappingsData } from './overview.fixtures';
 
-const mockMode = false;
+const mockMode = globalMockMode;
 
 export const showMappingWizardAction = () => dispatch => {
   dispatch({

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedActions.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedActions.js
@@ -1,10 +1,10 @@
 import URI from 'urijs';
-import API from '../../../../../../../common/API';
+import API, { globalMockMode } from '../../../../../../../common/API';
 
 import { FETCH_V2V_MIGRATIONS_COMPLETED } from './MigrationsCompletedConstants';
 import { requestCompletedServiceRequests } from './migrationsCompleted.fixtures';
 
-const mockMode = false;
+const mockMode = globalMockMode;
 
 const _getMigrationsCompletedAction = url => dispatch => {
   if (mockMode) {

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedCard.js
@@ -4,9 +4,32 @@ import { Icon, Spinner } from 'patternfly-react';
 import MigrationCompletedRow from './MigrationCompletedRow';
 
 class MigrationsCompletedCard extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isFetchingMigrationsCompleted: false
+    };
+  }
   componentDidMount() {
     const { fetchMigrationsCompletedAction } = this.props;
+    // fetch migrations completed initially, then poll them
     fetchMigrationsCompletedAction();
+    setInterval(fetchMigrationsCompletedAction, 10000);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // make the loading animation smooth - delay three seconds even if the backend is immediate
+    if (nextProps.isFetchingMigrationsCompleted) {
+      this.setState({
+        isFetchingMigrationsCompleted: true
+      });
+    } else {
+      setTimeout(() => {
+        this.setState({
+          isFetchingMigrationsCompleted: false
+        });
+      }, 3000);
+    }
   }
 
   renderCompletedMigrations() {
@@ -24,10 +47,11 @@ class MigrationsCompletedCard extends React.Component {
   render() {
     const {
       isRejectedMigrationsCompleted,
-      isFetchingMigrationsCompleted,
       errorMigrationsCompleted,
       migrationsCompleted
     } = this.props;
+
+    const { isFetchingMigrationsCompleted } = this.state;
 
     return (
       <div className="card-pf">

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedCard.js
@@ -1,14 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon, Spinner, bindMethods } from 'patternfly-react';
+import { Icon, bindMethods } from 'patternfly-react';
 import MigrationCompletedRow from './MigrationCompletedRow';
 
 class MigrationsCompletedCard extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      isFetchingMigrationsCompleted: false
-    };
     bindMethods(this, ['stopPolling', 'startPolling']);
   }
 
@@ -20,18 +17,6 @@ class MigrationsCompletedCard extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    // make the loading animation smooth - delay three seconds even if the backend is immediate
-    if (nextProps.isFetchingMigrationsCompleted) {
-      this.setState({
-        isFetchingMigrationsCompleted: true
-      });
-    } else if (!nextProps.isFetchingMigrationsCompleted) {
-      setTimeout(() => {
-        this.setState({
-          isFetchingMigrationsCompleted: false
-        });
-      }, 3000);
-    }
     // kill interval if a wizard becomes visble
     if (nextProps.mappingWizardVisible || nextProps.planWizardVisible) {
       this.stopPolling();
@@ -50,7 +35,7 @@ class MigrationsCompletedCard extends React.Component {
 
   startPolling() {
     const { fetchMigrationsCompletedAction } = this.props;
-    this.pollingInterval = setInterval(fetchMigrationsCompletedAction, 10000);
+    this.pollingInterval = setInterval(fetchMigrationsCompletedAction, 3000);
   }
 
   stopPolling() {
@@ -79,8 +64,6 @@ class MigrationsCompletedCard extends React.Component {
       migrationsCompleted
     } = this.props;
 
-    const { isFetchingMigrationsCompleted } = this.state;
-
     return (
       <div className="card-pf">
         <div className="card-pf-heading">
@@ -89,14 +72,14 @@ class MigrationsCompletedCard extends React.Component {
           </h2>
         </div>
         <div className="card-pf-body">
-          {isFetchingMigrationsCompleted && (
+          {/** isFetchingMigrationsCompleted && (
             <React.Fragment>
               <Spinner size="xs" inline loading />
               <span className="message-text">
                 {__('Loading completed migrations in progress')}
               </span>
             </React.Fragment>
-          )}
+          )* */}
           {isRejectedMigrationsCompleted && (
             <React.Fragment>
               <Icon type="pf" name="error-circle-o" />
@@ -116,7 +99,7 @@ class MigrationsCompletedCard extends React.Component {
 
 MigrationsCompletedCard.propTypes = {
   fetchMigrationsCompletedAction: PropTypes.func,
-  isFetchingMigrationsCompleted: PropTypes.bool,
+  /* isFetchingMigrationsCompleted: PropTypes.bool, */
   migrationsCompleted: PropTypes.arrayOf(PropTypes.object),
   isRejectedMigrationsCompleted: PropTypes.bool,
   errorMigrationsCompleted: PropTypes.object,
@@ -125,7 +108,7 @@ MigrationsCompletedCard.propTypes = {
 };
 MigrationsCompletedCard.defaultProps = {
   migrationsCompleted: [],
-  isFetchingMigrationsCompleted: false,
+  /** isFetchingMigrationsCompleted: false, */
   isRejectedMigrationsCompleted: false,
   errorMigrationsCompleted: null,
   mappingWizardVisible: false,

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedCard.js
@@ -14,7 +14,7 @@ class MigrationsCompletedCard extends React.Component {
     const { fetchMigrationsCompletedAction } = this.props;
     // fetch migrations completed initially, then poll them
     fetchMigrationsCompletedAction();
-    setInterval(fetchMigrationsCompletedAction, 10000);
+    this.pollingInterval = setInterval(fetchMigrationsCompletedAction, 10000);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -30,6 +30,10 @@ class MigrationsCompletedCard extends React.Component {
         });
       }, 3000);
     }
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.pollingInterval);
   }
 
   renderCompletedMigrations() {

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedSelectors.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedSelectors.js
@@ -1,0 +1,4 @@
+export const migrationsCompletedOverviewFilter = overview => ({
+  mappingWizardVisible: overview.mappingWizardVisible,
+  planWizardVisible: overview.planWizardVisible
+});

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/__tests__/index.test.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/__tests__/index.test.js
@@ -5,8 +5,16 @@ import { createStore, applyMiddleware, combineReducers } from 'redux';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import { initialState } from '../migrationsCompleted.fixtures';
+import { initialState as overviewInitialState } from '../../../../overview.fixtures';
+import { reducers as overviewReducer } from '../../../../index';
 import MigrationsCompletedCard from '../index';
 import reducer from '../MigrationsCompletedReducer';
+
+import { coreComponents } from '../../../../../../../../components';
+import componentRegistry from '../../../../../../../../components/componentRegistry';
+
+jest.mock('../../../../../../../../components/componentRegistry.js');
+componentRegistry.registerMultiple(coreComponents);
 
 const reducers = { migrationsCompleted: reducer };
 
@@ -14,9 +22,10 @@ describe('MigrationsCompletedCard integration test', () => {
   const middlewares = [thunk, promiseMiddleware()];
   const generateStore = () =>
     createStore(
-      combineReducers({ ...reducers }),
+      combineReducers({ ...reducers, overview: overviewReducer.overview }),
       {
-        migrationsCompleted: initialState
+        migrationsCompleted: initialState,
+        overview: overviewInitialState
       },
       applyMiddleware(...middlewares)
     );

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/index.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/index.js
@@ -3,13 +3,18 @@ import { connect } from 'react-redux';
 import MigrationsCompletedCard from './MigrationsCompletedCard';
 import reducer from './MigrationsCompletedReducer';
 import * as MigrationsCompletedActions from './MigrationsCompletedActions';
+import { migrationsCompletedOverviewFilter } from './MigrationsCompletedSelectors';
 
 export const reducers = { migrationsCompleted: reducer };
 
-const mapStateToProps = ({ migrationsCompleted }, ownProps) => ({
-  ...migrationsCompleted,
-  ...ownProps.data
-});
+const mapStateToProps = ({ migrationsCompleted, overview }, ownProps) => {
+  const selectedOverview = migrationsCompletedOverviewFilter(overview);
+  return {
+    ...migrationsCompleted,
+    ...selectedOverview,
+    ...ownProps.data
+  };
+};
 
 const mergeProps = (stateProps, dispatchProps, ownProps) =>
   Object.assign(stateProps, ownProps.data, dispatchProps);

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/MigrationsInProgressActions.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/MigrationsInProgressActions.js
@@ -1,10 +1,10 @@
 import URI from 'urijs';
-import API from '../../../../../../../common/API';
+import API, { globalMockMode } from '../../../../../../../common/API';
 
 import { FETCH_V2V_MIGRATIONS_IN_PROGRESS } from './MigrationsInProgressConstants';
 import { requestActiveServiceRequests } from './migrationsInProgress.fixtures';
 
-const mockMode = false;
+const mockMode = globalMockMode;
 
 const _getMigrationsInProgressAction = url => dispatch => {
   if (mockMode) {

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/MigrationsInProgressCard.js
@@ -14,7 +14,7 @@ class MigrationsInProgressCard extends React.Component {
     const { fetchMigrationsInProgressAction } = this.props;
     // fetch migrations in progress initially, then poll them
     fetchMigrationsInProgressAction();
-    setInterval(fetchMigrationsInProgressAction, 10000);
+    this.pollingInterval = setInterval(fetchMigrationsInProgressAction, 10000);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -30,6 +30,10 @@ class MigrationsInProgressCard extends React.Component {
         });
       }, 3000);
     }
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.pollingInterval);
   }
 
   renderActiveMigrations() {

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/MigrationsInProgressCard.js
@@ -4,9 +4,32 @@ import { Grid, Icon, Spinner } from 'patternfly-react';
 import MigrationInProgressCard from './MigrationInProgressCard';
 
 class MigrationsInProgressCard extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isFetchingMigrationsInProgress: false
+    };
+  }
   componentDidMount() {
     const { fetchMigrationsInProgressAction } = this.props;
+    // fetch migrations in progress initially, then poll them
     fetchMigrationsInProgressAction();
+    setInterval(fetchMigrationsInProgressAction, 10000);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // make the loading animation smooth - delay three seconds even if the backend is immediate
+    if (nextProps.isFetchingMigrationsInProgress) {
+      this.setState({
+        isFetchingMigrationsInProgress: true
+      });
+    } else {
+      setTimeout(() => {
+        this.setState({
+          isFetchingMigrationsInProgress: false
+        });
+      }, 3000);
+    }
   }
 
   renderActiveMigrations() {
@@ -26,10 +49,11 @@ class MigrationsInProgressCard extends React.Component {
   render() {
     const {
       isRejectedMigrationsInProgress,
-      isFetchingMigrationsInProgress,
       errorMigrationsInProgress,
       migrationsInProgress
     } = this.props;
+
+    const { isFetchingMigrationsInProgress } = this.state;
 
     return (
       <div className="card-pf card-pf-multi-card-container">

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/MigrationsInProgressCard.js
@@ -1,14 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Icon, Spinner, bindMethods } from 'patternfly-react';
+import { Grid, Icon, bindMethods } from 'patternfly-react';
 import MigrationInProgressCard from './MigrationInProgressCard';
 
 class MigrationsInProgressCard extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      isFetchingMigrationsInProgress: false
-    };
     bindMethods(this, ['stopPolling', 'startPolling']);
   }
   componentDidMount() {
@@ -19,18 +16,6 @@ class MigrationsInProgressCard extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    // make the loading animation smooth - delay three seconds even if the backend is immediate
-    if (nextProps.isFetchingMigrationsInProgress) {
-      this.setState({
-        isFetchingMigrationsInProgress: true
-      });
-    } else if (!nextProps.isFetchingMigrationsInProgress) {
-      setTimeout(() => {
-        this.setState({
-          isFetchingMigrationsInProgress: false
-        });
-      }, 3000);
-    }
     // kill interval if a wizard becomes visble
     if (nextProps.mappingWizardVisible || nextProps.planWizardVisible) {
       this.stopPolling();
@@ -49,7 +34,7 @@ class MigrationsInProgressCard extends React.Component {
 
   startPolling() {
     const { fetchMigrationsInProgressAction } = this.props;
-    this.pollingInterval = setInterval(fetchMigrationsInProgressAction, 10000);
+    this.pollingInterval = setInterval(fetchMigrationsInProgressAction, 3000);
   }
 
   stopPolling() {
@@ -80,8 +65,6 @@ class MigrationsInProgressCard extends React.Component {
       migrationsInProgress
     } = this.props;
 
-    const { isFetchingMigrationsInProgress } = this.state;
-
     return (
       <div className="card-pf card-pf-multi-card-container">
         <div className="card-pf-heading">
@@ -93,14 +76,14 @@ class MigrationsInProgressCard extends React.Component {
           </h2>
         </div>
         <div className="card-pf-body">
-          {isFetchingMigrationsInProgress && (
+          {/** isFetchingMigrationsInProgress && (
             <React.Fragment>
               <Spinner size="xs" inline loading />
               <span className="message-text">
                 {__('Loading migrations in progress')}
               </span>
             </React.Fragment>
-          )}
+          )* */}
           {isRejectedMigrationsInProgress && (
             <React.Fragment>
               <Icon type="pf" name="error-circle-o" />
@@ -120,7 +103,7 @@ class MigrationsInProgressCard extends React.Component {
 
 MigrationsInProgressCard.propTypes = {
   fetchMigrationsInProgressAction: PropTypes.func,
-  isFetchingMigrationsInProgress: PropTypes.bool,
+  /** isFetchingMigrationsInProgress: PropTypes.bool, */
   migrationsInProgress: PropTypes.arrayOf(PropTypes.object),
   isRejectedMigrationsInProgress: PropTypes.bool,
   errorMigrationsInProgress: PropTypes.object,
@@ -129,7 +112,7 @@ MigrationsInProgressCard.propTypes = {
 };
 MigrationsInProgressCard.defaultProps = {
   migrationsInProgress: [],
-  isFetchingMigrationsInProgress: false,
+  /** isFetchingMigrationsInProgress: false, */
   isRejectedMigrationsInProgress: false,
   errorMigrationsInProgress: null,
   mappingWizardVisible: false,

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/MigrationsInProgressSelectors.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/MigrationsInProgressSelectors.js
@@ -1,0 +1,4 @@
+export const migrationsInProgressOverviewFilter = overview => ({
+  mappingWizardVisible: overview.mappingWizardVisible,
+  planWizardVisible: overview.planWizardVisible
+});

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/__tests__/index.test.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/__tests__/index.test.js
@@ -5,8 +5,16 @@ import { createStore, applyMiddleware, combineReducers } from 'redux';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import { initialState } from '../migrationsInProgress.fixtures';
+import { initialState as overviewInitialState } from '../../../../overview.fixtures';
+import { reducers as overviewReducer } from '../../../../index';
 import MigrationsInProgressCard from '../index';
 import reducer from '../MigrationsInProgressReducer';
+
+import { coreComponents } from '../../../../../../../../components';
+import componentRegistry from '../../../../../../../../components/componentRegistry';
+
+jest.mock('../../../../../../../../components/componentRegistry.js');
+componentRegistry.registerMultiple(coreComponents);
 
 const reducers = { migrationsInProgress: reducer };
 
@@ -14,9 +22,10 @@ describe('Active ActiveMigrations integration test', () => {
   const middlewares = [thunk, promiseMiddleware()];
   const generateStore = () =>
     createStore(
-      combineReducers({ ...reducers }),
+      combineReducers({ ...reducers, overview: overviewReducer.overview }),
       {
-        migrationsInProgress: initialState
+        migrationsInProgress: initialState,
+        overview: overviewInitialState
       },
       applyMiddleware(...middlewares)
     );

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/index.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/index.js
@@ -3,13 +3,18 @@ import { connect } from 'react-redux';
 import MigrationsInProgressCard from './MigrationsInProgressCard';
 import reducer from './MigrationsInProgressReducer';
 import * as MigrationsInProgressActions from './MigrationsInProgressActions';
+import { migrationsInProgressOverviewFilter } from './MigrationsInProgressSelectors';
 
 export const reducers = { migrationsInProgress: reducer };
 
-const mapStateToProps = ({ migrationsInProgress }, ownProps) => ({
-  ...migrationsInProgress,
-  ...ownProps.data
-});
+const mapStateToProps = ({ migrationsInProgress, overview }, ownProps) => {
+  const selectedOverview = migrationsInProgressOverviewFilter(overview);
+  return {
+    ...migrationsInProgress,
+    ...selectedOverview,
+    ...ownProps.data
+  };
+};
 
 const mergeProps = (stateProps, dispatchProps, ownProps) =>
   Object.assign(stateProps, ownProps.data, dispatchProps);

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepActions.js
@@ -1,5 +1,5 @@
 import URI from 'urijs';
-import API from '../../../../../../../../common/API';
+import API, { globalMockMode } from '../../../../../../../../common/API';
 import {
   FETCH_V2V_SOURCE_CLUSTERS,
   FETCH_V2V_TARGET_CLUSTERS
@@ -10,7 +10,7 @@ import {
   requestTargetClustersData
 } from './mappingWizardClustersStep.fixtures';
 
-const mockMode = false;
+const mockMode = globalMockMode;
 
 const _getSourceClustersActionCreator = url => dispatch =>
   dispatch({

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
@@ -1,5 +1,5 @@
 import URI from 'urijs';
-import API from '../../../../../../../../common/API';
+import API, { globalMockMode } from '../../../../../../../../common/API';
 import {
   FETCH_V2V_SOURCE_DATASTORES,
   FETCH_V2V_TARGET_DATASTORES
@@ -9,7 +9,7 @@ import {
   requestTargetDatastoresData
 } from './mappingWizardDatastoresStep.fixtures';
 
-const mockMode = false;
+const mockMode = globalMockMode;
 
 const _filterSourceDatastores = response => {
   const { data } = response;

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepActions.js
@@ -1,5 +1,5 @@
 import URI from 'urijs';
-import API from '../../../../../../../../common/API';
+import API, { globalMockMode } from '../../../../../../../../common/API';
 import {
   FETCH_V2V_SOURCE_NETWORKS,
   FETCH_V2V_TARGET_NETWORKS
@@ -9,7 +9,7 @@ import {
   requestTargetNetworksData
 } from './mappingWizardNetworksStep.fixtures';
 
-const mockMode = false;
+const mockMode = globalMockMode;
 
 const _filterSourceNetworks = response => {
   const { data } = response;

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStepActions.js
@@ -1,9 +1,9 @@
-import API from '../../../../../../../../common/API';
+import API, { globalMockMode } from '../../../../../../../../common/API';
 import { POST_V2V_TRANSFORM_MAPPINGS } from './MappingWizardResultsStepConstants';
 import { CONTINUE_TO_PLAN } from '../../../../OverviewConstants';
 import { requestTransformationMappingsData } from './mappingWizardResultsStep.fixtures';
 
-const mockMode = false;
+const mockMode = globalMockMode;
 
 export const continueToPlanAction = id => dispatch => {
   dispatch({

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStepActions.js
@@ -1,4 +1,4 @@
-import API from '../../../../../../../../common/API';
+import API, { globalMockMode } from '../../../../../../../../common/API';
 import {
   POST_V2V_MIGRATION_PLANS,
   POST_V2V_MIGRATION_REQUESTS
@@ -8,7 +8,7 @@ import {
   requestMigrationRequestsData
 } from './planWizardResultsStep.fixtures';
 
-const mockMode = false;
+const mockMode = globalMockMode;
 
 const postMigrationRequestsAction = (response, dispatch) => {
   dispatch({


### PR DESCRIPTION
* introduce a `globalMock` setting for globally toggling all mock modes
* poll the active/completed migrations every 10 seconds. Ensure the spinner animation lasts 3 seconds (and doesn't go away immediately).