### PR TITLE
Unhappy errors

### DIFF
--- a/app/javascript/react/screens/App/Overview/__test__/__snapshots__/Overview.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/__test__/__snapshots__/Overview.test.js.snap
@@ -13,26 +13,16 @@ exports[`Overview component renders the overview 1`] = `
     }
   >
     <Col
-      bsClass="col"
-      componentClass="div"
       md={12}
     >
-      <Row
-        bsClass="row"
-        componentClass="div"
-      >
+      <Row>
         <div
           className="spacer"
         />
         <Equalizer
-          byRow={true}
-          enabled={[Function]}
           nodes={[Function]}
-          property="height"
         >
           <Col
-            bsClass="col"
-            componentClass="div"
             md={6}
             xs={12}
           >
@@ -42,8 +32,6 @@ exports[`Overview component renders the overview 1`] = `
             />
           </Col>
           <Col
-            bsClass="col"
-            componentClass="div"
             md={6}
             xs={12}
           >
@@ -55,25 +43,15 @@ exports[`Overview component renders the overview 1`] = `
           </Col>
         </Equalizer>
       </Row>
-      <Row
-        bsClass="row"
-        componentClass="div"
-      >
+      <Row>
         <Col
-          bsClass="col"
-          componentClass="div"
           xs={12}
         >
           <Connect(MigrationsInProgressCard) />
         </Col>
       </Row>
-      <Row
-        bsClass="row"
-        componentClass="div"
-      >
+      <Row>
         <Col
-          bsClass="col"
-          componentClass="div"
           xs={12}
         >
           <Connect(MigrationsCompletedCard) />

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/__tests__/__snapshots__/MigrationFailedVMsList.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/__tests__/__snapshots__/MigrationFailedVMsList.test.js.snap
@@ -3,17 +3,10 @@
 exports[`MigrationFailedVMsList component renders the MigrationsCompletedCard 1`] = `
 <React.Fragment>
   <Grid
-    bsClass="container"
-    componentClass="div"
     fluid={true}
   >
-    <Row
-      bsClass="row"
-      componentClass="div"
-    >
+    <Row>
       <Col
-        bsClass="col"
-        componentClass="div"
         md={3}
         xs={4}
       >
@@ -22,8 +15,6 @@ exports[`MigrationFailedVMsList component renders the MigrationsCompletedCard 1`
         </strong>
       </Col>
       <Col
-        bsClass="col"
-        componentClass="div"
         md={9}
         xs={8}
       >
@@ -34,14 +25,10 @@ exports[`MigrationFailedVMsList component renders the MigrationsCompletedCard 1`
     </Row>
   </Grid>
   <Grid
-    bsClass="container"
     className="failures-list"
-    componentClass="div"
     fluid={true}
   >
     <Row
-      bsClass="row"
-      componentClass="div"
       key="24"
     >
       <OverlayTrigger
@@ -65,9 +52,7 @@ exports[`MigrationFailedVMsList component renders the MigrationsCompletedCard 1`
         }
       >
         <Col
-          bsClass="col"
           className="failed-vm-column-text"
-          componentClass="div"
           md={3}
           xs={4}
         >
@@ -95,9 +80,7 @@ exports[`MigrationFailedVMsList component renders the MigrationsCompletedCard 1`
         }
       >
         <Col
-          bsClass="col"
           className="failed-vm-column-text"
-          componentClass="div"
           md={9}
           xs={8}
         >
@@ -106,8 +89,6 @@ exports[`MigrationFailedVMsList component renders the MigrationsCompletedCard 1`
       </OverlayTrigger>
     </Row>
     <Row
-      bsClass="row"
-      componentClass="div"
       key="25"
     >
       <OverlayTrigger
@@ -131,9 +112,7 @@ exports[`MigrationFailedVMsList component renders the MigrationsCompletedCard 1`
         }
       >
         <Col
-          bsClass="col"
           className="failed-vm-column-text"
-          componentClass="div"
           md={3}
           xs={4}
         >
@@ -161,9 +140,7 @@ exports[`MigrationFailedVMsList component renders the MigrationsCompletedCard 1`
         }
       >
         <Col
-          bsClass="col"
           className="failed-vm-column-text"
-          componentClass="div"
           md={9}
           xs={8}
         >
@@ -172,8 +149,6 @@ exports[`MigrationFailedVMsList component renders the MigrationsCompletedCard 1`
       </OverlayTrigger>
     </Row>
     <Row
-      bsClass="row"
-      componentClass="div"
       key="26"
     >
       <OverlayTrigger
@@ -197,9 +172,7 @@ exports[`MigrationFailedVMsList component renders the MigrationsCompletedCard 1`
         }
       >
         <Col
-          bsClass="col"
           className="failed-vm-column-text"
-          componentClass="div"
           md={3}
           xs={4}
         >
@@ -227,9 +200,7 @@ exports[`MigrationFailedVMsList component renders the MigrationsCompletedCard 1`
         }
       >
         <Col
-          bsClass="col"
           className="failed-vm-column-text"
-          componentClass="div"
           md={9}
           xs={8}
         >

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/__tests__/__snapshots__/MigrationsInProgressCard.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/__tests__/__snapshots__/MigrationsInProgressCard.test.js.snap
@@ -17,14 +17,9 @@ exports[`MigrationsInProgressCard component renders the ActiveMigrations 1`] = `
     className="card-pf-body"
   >
     <Grid
-      bsClass="container"
-      componentClass="div"
       fluid={true}
     >
-      <Row
-        bsClass="row"
-        componentClass="div"
-      >
+      <Row>
         <MigrationInProgressCard
           key="14"
           migration={

--- a/app/javascript/react/screens/App/Overview/components/ModalWizard/ModalWizard.scss
+++ b/app/javascript/react/screens/App/Overview/components/ModalWizard/ModalWizard.scss
@@ -8,11 +8,12 @@
 .modal-wizard-alert .modal-wizard-alert--alert {
   position: absolute;
   bottom: 0px;
-  width: calc(100% - 2px);
+  width: calc(100% - 40px);
   left: -1000px;
   transition: left 0.2s ease-in;
   z-index: 1;
   margin-bottom: 0;
+  margin-left: 20px;
 }
 
 .modal-wizard-alert .modal-wizard-alert--alert.is-visible {

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/__tests__/__snapshots__/MappingWizard.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/__tests__/__snapshots__/MappingWizard.test.js.snap
@@ -2,30 +2,9 @@
 
 exports[`MappingWizard component renders the mapping wizard 1`] = `
 <Modal
-  animation={true}
-  autoFocus={true}
-  backdrop={true}
-  bsClass="modal"
   dialogClassName="modal-lg wizard-pf"
-  dialogComponentClass={[Function]}
-  enforceFocus={true}
-  keyboard={true}
-  manager={
-    ModalManager {
-      "add": [Function],
-      "containers": Array [],
-      "data": Array [],
-      "handleContainerOverflow": true,
-      "hideSiblingNodes": true,
-      "isTopModal": [Function],
-      "modals": Array [],
-      "remove": [Function],
-    }
-  }
   onExited={[MockFunction]}
   onHide={[Function]}
-  renderBackdrop={[Function]}
-  restoreFocus={true}
   show={true}
 >
   <Wizard
@@ -33,9 +12,7 @@ exports[`MappingWizard component renders the mapping wizard 1`] = `
     embedded={false}
   >
     <ModalHeader
-      bsClass="modal-header"
       closeButton={false}
-      closeLabel="Close"
     >
       <button
         aria-hidden="true"
@@ -48,42 +25,30 @@ exports[`MappingWizard component renders the mapping wizard 1`] = `
           type="pf"
         />
       </button>
-      <ModalTitle
-        bsClass="modal-title"
-        componentClass="h4"
-      >
+      <ModalTitle>
         Infrastructure Mapping Wizard
       </ModalTitle>
     </ModalHeader>
     <ModalBody
-      bsClass="modal-body"
       className="wizard-pf-body clearfix"
-      componentClass="div"
     >
       <MappingWizardBody
-        activeStep="1"
         activeStepIndex={0}
         disableNextStep={false}
         goToStep={[Function]}
-        hideAlertAction={[Function]}
         loaded={true}
         mappingWizardClustersStep={Object {}}
         mappingWizardDatastoresStep={Object {}}
         mappingWizardGeneralStep={Object {}}
         mappingWizardNetworksStep={Object {}}
-        transformationsBody={Object {}}
       />
     </ModalBody>
     <ModalFooter
-      bsClass="modal-footer"
       className="wizard-pf-footer"
-      componentClass="div"
     >
       <Button
         active={false}
         block={false}
-        bsClass="btn"
-        bsStyle="default"
         className="btn-cancel"
         disabled={false}
         onClick={[Function]}
@@ -93,21 +58,17 @@ exports[`MappingWizard component renders the mapping wizard 1`] = `
       <Button
         active={false}
         block={false}
-        bsClass="btn"
-        bsStyle="default"
         disabled={true}
         onClick={[Function]}
       >
         <Icon
           name="angle-left"
-          type="fa"
         />
         Back
       </Button>
       <Button
         active={false}
         block={false}
-        bsClass="btn"
         bsStyle="primary"
         disabled={false}
         onClick={[Function]}
@@ -115,7 +76,6 @@ exports[`MappingWizard component renders the mapping wizard 1`] = `
         Next
         <Icon
           name="angle-right"
-          type="fa"
         />
       </Button>
     </ModalFooter>

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
@@ -1,13 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'patternfly-react';
+import { Button, noop, bindMethods } from 'patternfly-react';
 import { Field, reduxForm } from 'redux-form';
 import { length } from 'redux-form-validators';
 
 import ClustersStepForm from './components/ClustersStepForm';
 
 class MappingWizardClustersStep extends React.Component {
+  constructor(props) {
+    super(props);
+    bindMethods(this, ['fetchClusters']);
+  }
   componentDidMount() {
+    this.fetchClusters();
+  }
+
+  fetchClusters() {
     const {
       fetchSourceClustersUrl,
       fetchSourceClustersAction,
@@ -24,9 +32,29 @@ class MappingWizardClustersStep extends React.Component {
       isFetchingSourceClusters,
       sourceClusters,
       isFetchingTargetClusters,
-      targetClusters
+      targetClusters,
+      isRejectedSourceClusters,
+      isRejectedTargetClusters
     } = this.props;
 
+    if (isRejectedSourceClusters || isRejectedTargetClusters) {
+      return (
+        <div className="wizard-pf-complete blank-slate-pf">
+          <div className="wizard-pf-success-icon">
+            <span className="pficon pficon-error-circle-o" />
+          </div>
+          <h3 className="blank-slate-pf-main-action">
+            Error Retreiving Clusters
+          </h3>
+          <p className="blank-slate-pf-secondary-action">
+            We&apos;re sorry, something went wrong. Please try again.
+          </p>
+          <Button bsStyle="primary" onClick={this.fetchClusters}>
+            Retry
+          </Button>
+        </div>
+      );
+    }
     return (
       <Field
         name="clusterMappings"
@@ -49,7 +77,9 @@ MappingWizardClustersStep.propTypes = {
   sourceClusters: PropTypes.arrayOf(PropTypes.object),
   targetClusters: PropTypes.arrayOf(PropTypes.object),
   isFetchingSourceClusters: PropTypes.bool,
-  isFetchingTargetClusters: PropTypes.bool
+  isFetchingTargetClusters: PropTypes.bool,
+  isRejectedSourceClusters: PropTypes.bool,
+  isRejectedTargetClusters: PropTypes.bool
 };
 MappingWizardClustersStep.defaultProps = {
   fetchSourceClustersUrl: '',
@@ -57,7 +87,9 @@ MappingWizardClustersStep.defaultProps = {
   fetchTargetClustersUrl: '',
   fetchTargetClustersAction: noop,
   isFetchingSourceClusters: true,
-  isFetchingTargetClusters: true
+  isFetchingTargetClusters: true,
+  isRejectedSourceClusters: false,
+  isRejectedTargetClusters: false
 };
 
 export default reduxForm({

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
@@ -44,13 +44,13 @@ class MappingWizardClustersStep extends React.Component {
             <span className="pficon pficon-error-circle-o" />
           </div>
           <h3 className="blank-slate-pf-main-action">
-            Error Retreiving Clusters
+            {__('Error Retrieving Clusters')}
           </h3>
           <p className="blank-slate-pf-secondary-action">
-            We&apos;re sorry, something went wrong. Please try again.
+            {__("We're sorry, something went wrong. Please try again.")}
           </p>
           <Button bsStyle="primary" onClick={this.fetchClusters}>
-            Retry
+            {__('Retry')}
           </Button>
         </div>
       );

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepReducer.js
@@ -54,6 +54,7 @@ export default (state = initialState, action) => {
       ) {
         return state
           .set('targetClusters', action.payload.data.resources[0].ems_clusters)
+          .set('isRejectedTargetClusters', false)
           .set('isFetchingTargetClusters', false);
       }
       return state

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepReducer.js
@@ -19,7 +19,9 @@ const initialState = Immutable({
 export default (state = initialState, action) => {
   switch (action.type) {
     case `${FETCH_V2V_SOURCE_CLUSTERS}_PENDING`:
-      return state.set('isFetchingSourceClusters', true);
+      return state
+        .set('isFetchingSourceClusters', true)
+        .set('isRejectedSourceClusters', false);
     case `${FETCH_V2V_SOURCE_CLUSTERS}_FULFILLED`:
       if (
         action.payload.data &&
@@ -41,7 +43,9 @@ export default (state = initialState, action) => {
         .set('isRejectedSourceClusters', true)
         .set('isFetchingSourceClusters', false);
     case `${FETCH_V2V_TARGET_CLUSTERS}_PENDING`:
-      return state.set('isFetchingTargetClusters', true);
+      return state
+        .set('isFetchingTargetClusters', true)
+        .set('isRejectedTargetClusters', false);
     case `${FETCH_V2V_TARGET_CLUSTERS}_FULFILLED`:
       if (
         action.payload.data &&

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/__snapshots__/index.test.js.snap
@@ -8,6 +8,8 @@ Object {
   "fetchTargetClustersUrl": "/api/dummyProviders",
   "isFetchingSourceClusters": true,
   "isFetchingTargetClusters": true,
+  "isRejectedSourceClusters": false,
+  "isRejectedTargetClusters": false,
   "sourceClusters": Array [],
   "targetClusters": Array [],
 }

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -33,6 +33,28 @@ class MappingWizardDatastoresStep extends React.Component {
 
   componentDidMount() {}
 
+  componentWillReceiveProps(nextProps) {
+    const {
+      showAlertAction,
+      isRejectedSourceDatastores,
+      isRejectedTargetDatastores
+    } = this.props;
+
+    const { selectedCluster, selectedClusterMapping } = this.state;
+    if (
+      (isRejectedSourceDatastores !== nextProps.isRejectedSourceDatastores &&
+        nextProps.isRejectedSourceDatastores) ||
+      (isRejectedTargetDatastores !== nextProps.isRejectedTargetDatastores &&
+        nextProps.isRejectedTargetDatastores)
+    ) {
+      showAlertAction(
+        `Error retrieving cluster: ${selectedCluster.name} (${
+          selectedClusterMapping.name
+        })`
+      );
+    }
+  }
+
   selectSourceCluster(sourceClusterId) {
     // when dropdown selection occurs for source cluster, we go retrieve the datastores for that
     // cluster
@@ -66,9 +88,7 @@ class MappingWizardDatastoresStep extends React.Component {
     const {
       clusterMappings,
       isFetchingSourceDatastores,
-      isRejectedSourceDatastores, // eslint-disable-line no-unused-vars
       isFetchingTargetDatastores,
-      isRejectedTargetDatastores, // eslint-disable-line no-unused-vars
       // source/target datastores change depending on selection
       sourceDatastores,
       targetDatastores,

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -45,25 +45,23 @@ class MappingWizardDatastoresStep extends React.Component {
       isRejectedSourceDatastores !== nextProps.isRejectedSourceDatastores &&
       nextProps.isRejectedSourceDatastores
     ) {
-      showAlertAction(
-        __(
-          `Error retrieving cluster datastores: ${selectedCluster.name}, ID: ${
-            selectedCluster.id
-          }`
-        )
+      const msg = sprintf(
+        __('Error retrieving cluster datastores: %s, ID: %s'),
+        selectedCluster.name,
+        selectedCluster.id
       );
+      showAlertAction(msg);
     } else if (
       isRejectedTargetDatastores !== nextProps.isRejectedTargetDatastores &&
       nextProps.isRejectedTargetDatastores &&
       !isRejectedSourceDatastores
     ) {
-      showAlertAction(
-        __(
-          `Error retrieving cluster datastores: ${
-            selectedClusterMapping.name
-          }, ID: ${selectedClusterMapping.id}`
-        )
+      const msg = sprintf(
+        __('Error retrieving cluster datastores: %s, ID: %s'),
+        selectedClusterMapping.name,
+        selectedClusterMapping.id
       );
+      showAlertAction(msg);
     }
   }
 

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -54,7 +54,8 @@ class MappingWizardDatastoresStep extends React.Component {
       );
     } else if (
       isRejectedTargetDatastores !== nextProps.isRejectedTargetDatastores &&
-      nextProps.isRejectedTargetDatastores
+      nextProps.isRejectedTargetDatastores &&
+      !isRejectedSourceDatastores
     ) {
       showAlertAction(
         __(

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -42,15 +42,26 @@ class MappingWizardDatastoresStep extends React.Component {
 
     const { selectedCluster, selectedClusterMapping } = this.state;
     if (
-      (isRejectedSourceDatastores !== nextProps.isRejectedSourceDatastores &&
-        nextProps.isRejectedSourceDatastores) ||
-      (isRejectedTargetDatastores !== nextProps.isRejectedTargetDatastores &&
-        nextProps.isRejectedTargetDatastores)
+      isRejectedSourceDatastores !== nextProps.isRejectedSourceDatastores &&
+      nextProps.isRejectedSourceDatastores
     ) {
       showAlertAction(
-        `Error retrieving cluster: ${selectedCluster.name} (${
-          selectedClusterMapping.name
-        })`
+        __(
+          `Error retrieving cluster datastores: ${selectedCluster.name}, ID: ${
+            selectedCluster.id
+          }`
+        )
+      );
+    } else if (
+      isRejectedTargetDatastores !== nextProps.isRejectedTargetDatastores &&
+      nextProps.isRejectedTargetDatastores
+    ) {
+      showAlertAction(
+        __(
+          `Error retrieving cluster datastores: ${
+            selectedClusterMapping.name
+          }, ID: ${selectedClusterMapping.id}`
+        )
       );
     }
   }

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepReducer.js
@@ -19,7 +19,9 @@ const initialState = Immutable({
 export default (state = initialState, action) => {
   switch (action.type) {
     case `${FETCH_V2V_SOURCE_DATASTORES}_PENDING`:
-      return state.set('isFetchingSourceDatastores', true);
+      return state
+        .set('isFetchingSourceDatastores', true)
+        .set('isRejectedSourceDatastores', false);
     case `${FETCH_V2V_SOURCE_DATASTORES}_FULFILLED`:
       return state
         .set('sourceDatastores', action.payload.sourceDatastores)
@@ -32,7 +34,9 @@ export default (state = initialState, action) => {
         .set('isFetchingSourceDatastores', false);
 
     case `${FETCH_V2V_TARGET_DATASTORES}_PENDING`:
-      return state.set('isFetchingTargetDatastores', true);
+      return state
+        .set('isFetchingTargetDatastores', true)
+        .set('isRejectedTargetDatastores', false);
     case `${FETCH_V2V_TARGET_DATASTORES}_FULFILLED`:
       return state
         .set('targetDatastores', action.payload.targetDatastores)

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
@@ -33,6 +33,28 @@ class MappingWizardNetworksStep extends React.Component {
 
   componentDidMount() {}
 
+  componentWillReceiveProps(nextProps) {
+    const {
+      showAlertAction,
+      isRejectedSourceNetworks,
+      isRejectedTargetNetworks
+    } = this.props;
+
+    const { selectedCluster, selectedClusterMapping } = this.state;
+    if (
+      (isRejectedSourceNetworks !== nextProps.isRejectedSourceNetworks &&
+        nextProps.isRejectedSourceNetworks) ||
+      (isRejectedTargetNetworks !== nextProps.isRejectedTargetNetworks &&
+        nextProps.isRejectedTargetNetworks)
+    ) {
+      showAlertAction(
+        `Error retrieving cluster: ${selectedCluster.name} (${
+          selectedClusterMapping.name
+        })`
+      );
+    }
+  }
+
   selectSourceCluster(sourceClusterId) {
     // when dropdown selection occurs for source cluster, we go retrieve the
     // newworks for that cluster
@@ -66,9 +88,7 @@ class MappingWizardNetworksStep extends React.Component {
     const {
       clusterMappings,
       isFetchingSourceNetworks,
-      isRejectedSourceNetworks, // eslint-disable-line no-unused-vars
       isFetchingTargetNetworks,
-      isRejectedTargetNetworks, // eslint-disable-line no-unused-vars
       sourceNetworks,
       targetNetworks,
       form
@@ -113,7 +133,8 @@ MappingWizardNetworksStep.propTypes = {
   isFetchingTargetNetworks: PropTypes.bool,
   isRejectedTargetNetworks: PropTypes.bool,
   form: PropTypes.string,
-  pristine: PropTypes.bool
+  pristine: PropTypes.bool,
+  showAlertAction: PropTypes.func
 };
 MappingWizardNetworksStep.defaultProps = {
   clusterMappings: [],
@@ -127,7 +148,8 @@ MappingWizardNetworksStep.defaultProps = {
   isFetchingTargetNetworks: false,
   isRejectedTargetNetworks: false,
   form: '',
-  pristine: true
+  pristine: true,
+  showAlertAction: noop
 };
 
 export default reduxForm({

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
@@ -55,7 +55,8 @@ class MappingWizardNetworksStep extends React.Component {
       );
     } else if (
       isRejectedTargetNetworks !== nextProps.isRejectedTargetNetworks &&
-      nextProps.isRejectedTargetNetworks
+      nextProps.isRejectedTargetNetworks &&
+      !isRejectedSourceNetworks
     ) {
       showAlertAction(
         __(

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
@@ -41,16 +41,28 @@ class MappingWizardNetworksStep extends React.Component {
     } = this.props;
 
     const { selectedCluster, selectedClusterMapping } = this.state;
+
     if (
-      (isRejectedSourceNetworks !== nextProps.isRejectedSourceNetworks &&
-        nextProps.isRejectedSourceNetworks) ||
-      (isRejectedTargetNetworks !== nextProps.isRejectedTargetNetworks &&
-        nextProps.isRejectedTargetNetworks)
+      isRejectedSourceNetworks !== nextProps.isRejectedSourceNetworks &&
+      nextProps.isRejectedSourceNetworks
     ) {
       showAlertAction(
-        `Error retrieving cluster: ${selectedCluster.name} (${
-          selectedClusterMapping.name
-        })`
+        __(
+          `Error retrieving cluster networks: ${selectedCluster.name}, ID: ${
+            selectedCluster.id
+          }`
+        )
+      );
+    } else if (
+      isRejectedTargetNetworks !== nextProps.isRejectedTargetNetworks &&
+      nextProps.isRejectedTargetNetworks
+    ) {
+      showAlertAction(
+        __(
+          `Error retrieving cluster networks: ${
+            selectedClusterMapping.name
+          }, ID: ${selectedClusterMapping.id}`
+        )
       );
     }
   }

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
@@ -46,25 +46,23 @@ class MappingWizardNetworksStep extends React.Component {
       isRejectedSourceNetworks !== nextProps.isRejectedSourceNetworks &&
       nextProps.isRejectedSourceNetworks
     ) {
-      showAlertAction(
-        __(
-          `Error retrieving cluster networks: ${selectedCluster.name}, ID: ${
-            selectedCluster.id
-          }`
-        )
+      const msg = sprintf(
+        __('Error retrieving cluster networks: %s, ID: %s'),
+        selectedCluster.name,
+        selectedCluster.id
       );
+      showAlertAction(msg);
     } else if (
       isRejectedTargetNetworks !== nextProps.isRejectedTargetNetworks &&
       nextProps.isRejectedTargetNetworks &&
       !isRejectedSourceNetworks
     ) {
-      showAlertAction(
-        __(
-          `Error retrieving cluster networks: ${
-            selectedClusterMapping.name
-          }, ID: ${selectedClusterMapping.id}`
-        )
+      const msg = sprintf(
+        __('Error retrieving cluster networks: %s, ID: %s'),
+        selectedClusterMapping.name,
+        selectedClusterMapping.id
       );
+      showAlertAction(msg);
     }
   }
 

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepReducer.js
@@ -19,7 +19,9 @@ const initialState = Immutable({
 export default (state = initialState, action) => {
   switch (action.type) {
     case `${FETCH_V2V_SOURCE_NETWORKS}_PENDING`:
-      return state.set('isFetchingSourceNetworks', true);
+      return state
+        .set('isFetchingSourceNetworks', true)
+        .set('isRejectedSourceNetworks', false);
     case `${FETCH_V2V_SOURCE_NETWORKS}_FULFILLED`:
       return state
         .set('sourceNetworks', action.payload.sourceNetworks)
@@ -32,7 +34,9 @@ export default (state = initialState, action) => {
         .set('isFetchingSourceNetworks', false);
 
     case `${FETCH_V2V_TARGET_NETWORKS}_PENDING`:
-      return state.set('isFetchingTargetNetworks', true);
+      return state
+        .set('isFetchingTargetNetworks', true)
+        .set('isRejectedTargetNetworks', false);
     case `${FETCH_V2V_TARGET_NETWORKS}_FULFILLED`:
       return state
         .set('targetNetworks', action.payload.targetNetworks)

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import MappingWizardNetworksStep from './MappingWizardNetworksStep';
 import * as MappingWizardNetworksStepActions from './MappingWizardNetworksStepActions';
+import { showAlertAction } from '../../MappingWizardActions';
 
 import reducer from './MappingWizardNetworksStepReducer';
 
@@ -12,11 +13,14 @@ const mapStateToProps = ({ mappingWizardNetworksStep, form }, ownProps) => ({
   clusterMappings: form.mappingWizardClustersStep.values.clusterMappings
 });
 
+const actions = {
+  ...MappingWizardNetworksStepActions,
+  showAlertAction
+};
+
 const mergeProps = (stateProps, dispatchProps, ownProps) =>
   Object.assign(stateProps, ownProps.data, dispatchProps);
 
-export default connect(
-  mapStateToProps,
-  MappingWizardNetworksStepActions,
-  mergeProps
-)(MappingWizardNetworksStep);
+export default connect(mapStateToProps, actions, mergeProps)(
+  MappingWizardNetworksStep
+);


### PR DESCRIPTION
Closes #109 

Step 2: 
Display the error message centrally and wire up the "retry" button to re-fetch clusters. Next button is disabled (as no clusters can be mapped).


![screen shot 2018-03-07 at 2 23 33 pm](https://user-images.githubusercontent.com/4237045/37113456-6bdab04e-2213-11e8-8dea-6da9c5c95137.png)


Step 3:
Display the error message in an alert. On load, we will always be selecting the first source cluster, and if it fails, display the alert. If source cluster is selected again and fails or any other source cluster fails, update the alert. Alert can be closed at any point while mappings are still in display.

**Update**: since these are really two API calls to retrieve data stores for source and data stores for target, update the messaging to reflect this. Also - adding some adequate spacing to distinguish the alert from the wizard.

Selected Source Cluster Fails to load Datastores:
![screen shot 2018-03-07 at 2 16 20 pm](https://user-images.githubusercontent.com/4237045/37113620-e5e30ff8-2213-11e8-9d2c-b4ae170ac5ca.png)

Selected Target Cluster Fails to load Datastores:
![screen shot 2018-03-07 at 2 14 38 pm](https://user-images.githubusercontent.com/4237045/37113632-f10279a0-2213-11e8-896e-263d339d5845.png)
 


Step 4:
Selected Source Cluster Fails to load Networks:


![screen shot 2018-03-07 at 2 19 18 pm](https://user-images.githubusercontent.com/4237045/37113683-0dbd441c-2214-11e8-8807-87eda3f47045.png)


Selected Target Cluster Fails to load Networks:
![screen shot 2018-03-07 at 2 20 02 pm](https://user-images.githubusercontent.com/4237045/37113687-11dc9778-2214-11e8-920d-ab15850674dc.png)

Adding a retry button to the alert in steps 3/4 is a bit of stretch (have to wire up more actions for that). Leaving this alone for now.

@michaelkro can you sanity check this?
