### PR TITLE
Update component registry reference

### DIFF
--- a/app/javascript/components/componentRegistry.js
+++ b/app/javascript/components/componentRegistry.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { i18nProviderWrapperFactory } from '../common/i18nProviderWrapperFactory';
 
-const { componentRegistry } = window.MiqReact;
+const { componentRegistry } = window.ManageIQ.react;
 
 // extends current MIQ componentRegistry with i18nProviderWrapper
 componentRegistry.markup = (name, data, store) => {


### PR DESCRIPTION
#Please see
https://github.com/ManageIQ/manageiq-ui-classic/pull/3579/

### Issue
If you are on the current `master` branch of classic, attempting to go to v2v page results with the following console errors

```
Uncaught TypeError: Cannot read property 'componentRegistry' of undefined
    at Object.89 (migration.js:14603)
    at __webpack_require__ (bootstrap 87da02a3be71cac3f5ef:54)
    at Object.745 (migration.js:2)
    at __webpack_require__ (bootstrap 87da02a3be71cac3f5ef:54)
    at Object.744 (InfrastructureMappings.js:4)
    at __webpack_require__ (bootstrap 87da02a3be71cac3f5ef:54)
    at webpackJsonpCallback (bootstrap 87da02a3be71cac3f5ef:25)
    at migration.js:1
componentRegistry.js:38 Uncaught Error: Component not found:  v2v_ui_plugin among 
    at Object.markup (componentRegistry.js:38)
    at Object.mount (mounter.js:10)
    at migration:1498
```