### PR TITLE
Refactor `removeNode()`

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/__tests__/DatastoresStepForm.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/__tests__/DatastoresStepForm.test.js
@@ -38,7 +38,7 @@ describe('#removeNode', () => {
   });
 
   test('removes selected target datastore along with its mapped source datastores', () => {
-    const [datastore1, datastore2] = sourceDatastores;
+    const [datastore1, datastore2, datastore3] = sourceDatastores;
     const [
       targetDatastoreToRemove,
       targetDatastoreShouldRemain
@@ -51,11 +51,11 @@ describe('#removeNode', () => {
           nodes: [
             {
               ...targetDatastoreToRemove,
-              nodes: [datastore1]
+              nodes: [datastore1, datastore2]
             },
             {
               ...targetDatastoreShouldRemain,
-              nodes: [datastore2]
+              nodes: [datastore3]
             }
           ]
         }
@@ -64,9 +64,10 @@ describe('#removeNode', () => {
 
     const wrapper = shallow(<DatastoresStepForm {...props} input={input} />);
 
-    wrapper.find('MappingWizardTreeView').prop('selectNode')(
-      targetDatastoreToRemove
-    );
+    wrapper.find('MappingWizardTreeView').prop('selectNode')({
+      ...targetDatastoreToRemove,
+      nodes: [datastore1, datastore2]
+    });
     wrapper.find('MappingWizardTreeView').prop('removeNode')();
 
     expect(input.onChange).toHaveBeenLastCalledWith([
@@ -75,7 +76,7 @@ describe('#removeNode', () => {
         nodes: [
           {
             ...targetDatastoreShouldRemain,
-            nodes: [datastore2]
+            nodes: [datastore3]
           }
         ]
       }
@@ -83,7 +84,7 @@ describe('#removeNode', () => {
   });
 
   test('removes entire datastores mapping if all target datastores are removed', () => {
-    const [datastore] = sourceDatastores;
+    const [datastore1, datastore2] = sourceDatastores;
     const [targetDatastoreToRemove] = targetDatastores;
     input = {
       ...input,
@@ -93,7 +94,7 @@ describe('#removeNode', () => {
           nodes: [
             {
               ...targetDatastoreToRemove,
-              nodes: [datastore]
+              nodes: [datastore1, datastore2]
             }
           ]
         }
@@ -102,9 +103,10 @@ describe('#removeNode', () => {
 
     const wrapper = shallow(<DatastoresStepForm {...props} input={input} />);
 
-    wrapper.find('MappingWizardTreeView').prop('selectNode')(
-      targetDatastoreToRemove
-    );
+    wrapper.find('MappingWizardTreeView').prop('selectNode')({
+      ...targetDatastoreToRemove,
+      nodes: [datastore1, datastore2]
+    });
     wrapper.find('MappingWizardTreeView').prop('removeNode')();
 
     expect(input.onChange).toHaveBeenLastCalledWith([]);

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
@@ -15,8 +15,8 @@ import {
   targetNetworkWithTreeViewAttrs,
   networkGroupingForRep,
   mappingsForTreeView,
-  removeTargetNetwork,
-  removeSourceNetwork
+  mappingWithTargetNetworkRemoved,
+  mappingWithSourceNetworkRemoved
 } from './helpers';
 
 class NetworksStepForm extends React.Component {
@@ -301,30 +301,45 @@ class NetworksStepForm extends React.Component {
     // --> Source network grouping(s)
 
     const updatedMappings = isTargetNetwork
-      ? networksStepMappings
-          .map(networksStepMapping =>
-            removeTargetNetwork(networksStepMapping, selectedNode)
-          )
-          .filter(item => item !== null)
-      : networksStepMappings
-          .map(networksStepMapping => {
+      ? networksStepMappings.reduce(
+          (updatedNetworksStepMappings, networksStepMapping) => {
+            const updatedMapping = mappingWithTargetNetworkRemoved(
+              networksStepMapping,
+              selectedNode
+            );
+            return updatedMapping
+              ? [...updatedNetworksStepMappings, updatedMapping]
+              : [...updatedNetworksStepMappings];
+          },
+          []
+        )
+      : networksStepMappings.reduce(
+          (updatedNetworksStepMappings, networksStepMapping) => {
             const {
               nodes: networksMappings,
               ...targetCluster
             } = networksStepMapping;
-            const updatedNetworksMappings = networksMappings
-              .map(networksMapping =>
-                removeSourceNetwork(networksMapping, selectedNode)
-              )
-              .filter(item => item !== null);
-            return updatedNetworksMappings.length === 0
-              ? null
-              : {
-                  ...targetCluster,
-                  nodes: updatedNetworksMappings
-                };
-          })
-          .filter(item => item !== null);
+            const updatedNodes = networksMappings.reduce(
+              (updatedNetworksMappings, networksMapping) => {
+                const updatedMapping = mappingWithSourceNetworkRemoved(
+                  networksMapping,
+                  selectedNode
+                );
+                return updatedMapping
+                  ? [...updatedNetworksMappings, updatedMapping]
+                  : [...updatedNetworksMappings];
+              },
+              []
+            );
+            return updatedNodes
+              ? [
+                  ...updatedNetworksStepMappings,
+                  { ...targetCluster, nodes: updatedNodes }
+                ]
+              : [...updatedNetworksStepMappings];
+          },
+          []
+        );
 
     onChange(updatedMappings);
     this.setState(() => ({ selectedNode: null }));

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
@@ -14,7 +14,9 @@ import {
   clustersMappingWithTreeViewAttrs,
   targetNetworkWithTreeViewAttrs,
   networkGroupingForRep,
-  mappingsForTreeView
+  mappingsForTreeView,
+  removeTargetNetwork,
+  removeSourceNetwork
 } from './helpers';
 
 class NetworksStepForm extends React.Component {
@@ -285,60 +287,46 @@ class NetworksStepForm extends React.Component {
     const { selectedNode } = this.state;
     const isTargetNetwork = selectedNode.nodes;
 
-    if (isTargetNetwork) {
-      const updatedMappings = networksStepMappings
-        .map(targetClusterWithNetworksMappings => {
-          const {
-            nodes: networksMappings,
-            ...targetCluster
-          } = targetClusterWithNetworksMappings;
-          const updatedNetworksMappings = networksMappings.filter(
-            targetNetworkWithSourceNetworks =>
-              targetNetworkWithSourceNetworks.id !== selectedNode.id
-          );
-          return updatedNetworksMappings.length === 0
-            ? undefined
-            : {
-                ...targetCluster,
-                nodes: updatedNetworksMappings
-              };
-        })
-        .filter(item => item !== undefined);
-      onChange(updatedMappings);
-    } else {
-      const updatedMappings = networksStepMappings
-        .map(targetClusterWithNetworksMappings => {
-          const {
-            nodes: networksMappings,
-            ...targetCluster
-          } = targetClusterWithNetworksMappings;
-          const updatedNetworksMappings = networksMappings
-            .map(networksMapping => {
-              const {
-                nodes: sourceNetworks,
-                ...targetNetwork
-              } = networksMapping;
-              const updatedSourceNetworks = sourceNetworks.filter(
-                sourceNetwork => sourceNetwork.uid_ems !== selectedNode.uid_ems
-              );
-              return updatedSourceNetworks.length === 0
-                ? undefined
-                : {
-                    ...targetNetwork,
-                    nodes: updatedSourceNetworks
-                  };
-            })
-            .filter(item => item !== undefined);
-          return updatedNetworksMappings.length === 0
-            ? undefined
-            : {
-                ...targetCluster,
-                nodes: updatedNetworksMappings
-              };
-        })
-        .filter(item => item !== undefined);
-      onChange(updatedMappings);
-    }
+    // *********************
+    // NETWORKS STEP MAPPING
+    // *********************
+    // Target Cluster
+    // --> Target Network
+    // ----> Source network grouping(s)
+
+    // ****************
+    // NETWORKS MAPPING
+    // ****************
+    // Target Network
+    // --> Source network grouping(s)
+
+    const updatedMappings = isTargetNetwork
+      ? networksStepMappings
+          .map(networksStepMapping =>
+            removeTargetNetwork(networksStepMapping, selectedNode)
+          )
+          .filter(item => item !== null)
+      : networksStepMappings
+          .map(networksStepMapping => {
+            const {
+              nodes: networksMappings,
+              ...targetCluster
+            } = networksStepMapping;
+            const updatedNetworksMappings = networksMappings
+              .map(networksMapping =>
+                removeSourceNetwork(networksMapping, selectedNode)
+              )
+              .filter(item => item !== null);
+            return updatedNetworksMappings.length === 0
+              ? null
+              : {
+                  ...targetCluster,
+                  nodes: updatedNetworksMappings
+                };
+          })
+          .filter(item => item !== null);
+
+    onChange(updatedMappings);
     this.setState(() => ({ selectedNode: null }));
   }
 

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/__tests__/__snapshots__/helpers.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/__tests__/__snapshots__/helpers.test.js.snap
@@ -263,6 +263,111 @@ Array [
 ]
 `;
 
+exports[`removeSourceNetwork removes all networks whose uid_ems matches that of the specified source network 1`] = `
+Object {
+  "allow_promiscuous": null,
+  "computed_allow_promiscuous": null,
+  "computed_forged_transmits": null,
+  "computed_mac_changes": null,
+  "created_on": "2017-06-01T04:24:18Z",
+  "forged_transmits": null,
+  "href": "http://localhost:3000/api/lans/10000000000019",
+  "id": "1-1",
+  "mac_changes": null,
+  "name": "RHV Cluster 1 - ovirtmgmt1",
+  "nodes": Array [
+    Object {
+      "allow_promiscuous": null,
+      "computed_allow_promiscuous": null,
+      "computed_forged_transmits": null,
+      "computed_mac_changes": null,
+      "created_on": "2017-06-01T04:24:18Z",
+      "forged_transmits": null,
+      "href": "http://localhost:3000/api/lans/10000000000009",
+      "id": "1-3",
+      "mac_changes": null,
+      "name": "VMWareCluster1-vm_network2",
+      "parent_id": null,
+      "switch_id": "1",
+      "tag": "24",
+      "uid_ems": "VMWareCluster1-vm_network2",
+      "updated_on": "2017-06-01T04:24:18Z",
+    },
+  ],
+  "parent_id": null,
+  "switch_id": "10000000000008",
+  "tag": null,
+  "uid_ems": "00000000-0000-0000-0000-000000000009",
+  "updated_on": "2017-06-01T04:24:18Z",
+}
+`;
+
+exports[`removeSourceNetwork returns null if no source networks remain 1`] = `null`;
+
+exports[`removeTargetNetwork removes the networks mapping for the specified target network 1`] = `
+Object {
+  "created_on": "2017-10-06T16:41:09Z",
+  "drs_automation_level": "fullyAutomated",
+  "drs_enabled": false,
+  "drs_migration_threshold": 3,
+  "effective_cpu": 109356,
+  "effective_memory": 790163881984,
+  "ems_id": "1",
+  "ems_ref": "domain-c7",
+  "ems_ref_obj": "domain-c7",
+  "ha_admit_control": true,
+  "ha_enabled": false,
+  "ha_max_failures": 1,
+  "href": "http://localhost:3000/api/clusters/1",
+  "id": "1",
+  "last_perf_capture_on": null,
+  "name": "RHV Cluster 1",
+  "nodes": Array [
+    Object {
+      "allow_promiscuous": null,
+      "computed_allow_promiscuous": null,
+      "computed_forged_transmits": null,
+      "computed_mac_changes": null,
+      "created_on": "2017-06-01T04:24:19Z",
+      "forged_transmits": null,
+      "href": "http://localhost:3000/api/lans/10000000000020",
+      "id": "1-2",
+      "mac_changes": null,
+      "name": "RHV Cluster 1 - ovirtmgmt2",
+      "nodes": Array [
+        Object {
+          "allow_promiscuous": null,
+          "computed_allow_promiscuous": null,
+          "computed_forged_transmits": null,
+          "computed_mac_changes": null,
+          "created_on": "2017-06-01T04:24:18Z",
+          "forged_transmits": null,
+          "href": "http://localhost:3000/api/lans/10000000000008",
+          "id": "1-2",
+          "mac_changes": null,
+          "name": "VMWareCluster1-vm_network1",
+          "parent_id": null,
+          "switch_id": "2",
+          "tag": "24",
+          "uid_ems": "VMWareCluster1-vm_network1",
+          "updated_on": "2017-06-01T04:24:18Z",
+        },
+      ],
+      "parent_id": null,
+      "switch_id": "10000000000015",
+      "tag": null,
+      "uid_ems": "00000000-0000-0000-0000-000000000009",
+      "updated_on": "2017-06-01T04:24:19Z",
+    },
+  ],
+  "type": null,
+  "uid_ems": "domain-c7",
+  "updated_on": "2018-01-20T23:12:00Z",
+}
+`;
+
+exports[`removeTargetNetwork returns null if no networks mappings remain 1`] = `null`;
+
 exports[`sourceNetworkWithTreeViewAttrs adds extra attributes for display in TreeView 1`] = `
 Object {
   "allow_promiscuous": null,

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/__tests__/__snapshots__/helpers.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/__tests__/__snapshots__/helpers.test.js.snap
@@ -150,6 +150,111 @@ Array [
 ]
 `;
 
+exports[`mappingWithSourceNetworkRemoved removes all networks whose uid_ems matches that of the specified source network 1`] = `
+Object {
+  "allow_promiscuous": null,
+  "computed_allow_promiscuous": null,
+  "computed_forged_transmits": null,
+  "computed_mac_changes": null,
+  "created_on": "2017-06-01T04:24:18Z",
+  "forged_transmits": null,
+  "href": "http://localhost:3000/api/lans/10000000000019",
+  "id": "1-1",
+  "mac_changes": null,
+  "name": "RHV Cluster 1 - ovirtmgmt1",
+  "nodes": Array [
+    Object {
+      "allow_promiscuous": null,
+      "computed_allow_promiscuous": null,
+      "computed_forged_transmits": null,
+      "computed_mac_changes": null,
+      "created_on": "2017-06-01T04:24:18Z",
+      "forged_transmits": null,
+      "href": "http://localhost:3000/api/lans/10000000000009",
+      "id": "1-3",
+      "mac_changes": null,
+      "name": "VMWareCluster1-vm_network2",
+      "parent_id": null,
+      "switch_id": "1",
+      "tag": "24",
+      "uid_ems": "VMWareCluster1-vm_network2",
+      "updated_on": "2017-06-01T04:24:18Z",
+    },
+  ],
+  "parent_id": null,
+  "switch_id": "10000000000008",
+  "tag": null,
+  "uid_ems": "00000000-0000-0000-0000-000000000009",
+  "updated_on": "2017-06-01T04:24:18Z",
+}
+`;
+
+exports[`mappingWithSourceNetworkRemoved returns null if no source networks remain 1`] = `null`;
+
+exports[`mappingWithTargetNetworkRemoved removes the networks mapping for the specified target network 1`] = `
+Object {
+  "created_on": "2017-10-06T16:41:09Z",
+  "drs_automation_level": "fullyAutomated",
+  "drs_enabled": false,
+  "drs_migration_threshold": 3,
+  "effective_cpu": 109356,
+  "effective_memory": 790163881984,
+  "ems_id": "1",
+  "ems_ref": "domain-c7",
+  "ems_ref_obj": "domain-c7",
+  "ha_admit_control": true,
+  "ha_enabled": false,
+  "ha_max_failures": 1,
+  "href": "http://localhost:3000/api/clusters/1",
+  "id": "1",
+  "last_perf_capture_on": null,
+  "name": "RHV Cluster 1",
+  "nodes": Array [
+    Object {
+      "allow_promiscuous": null,
+      "computed_allow_promiscuous": null,
+      "computed_forged_transmits": null,
+      "computed_mac_changes": null,
+      "created_on": "2017-06-01T04:24:19Z",
+      "forged_transmits": null,
+      "href": "http://localhost:3000/api/lans/10000000000020",
+      "id": "1-2",
+      "mac_changes": null,
+      "name": "RHV Cluster 1 - ovirtmgmt2",
+      "nodes": Array [
+        Object {
+          "allow_promiscuous": null,
+          "computed_allow_promiscuous": null,
+          "computed_forged_transmits": null,
+          "computed_mac_changes": null,
+          "created_on": "2017-06-01T04:24:18Z",
+          "forged_transmits": null,
+          "href": "http://localhost:3000/api/lans/10000000000008",
+          "id": "1-2",
+          "mac_changes": null,
+          "name": "VMWareCluster1-vm_network1",
+          "parent_id": null,
+          "switch_id": "2",
+          "tag": "24",
+          "uid_ems": "VMWareCluster1-vm_network1",
+          "updated_on": "2017-06-01T04:24:18Z",
+        },
+      ],
+      "parent_id": null,
+      "switch_id": "10000000000015",
+      "tag": null,
+      "uid_ems": "00000000-0000-0000-0000-000000000009",
+      "updated_on": "2017-06-01T04:24:19Z",
+    },
+  ],
+  "type": null,
+  "uid_ems": "domain-c7",
+  "updated_on": "2018-01-20T23:12:00Z",
+}
+`;
+
+exports[`mappingWithTargetNetworkRemoved returns null if no networks mappings remain 1`] = `null`;
+
 exports[`mappingsForTreeView reduces source networks to representatives for all networks step mappings 1`] = `
 Array [
   Object {
@@ -262,111 +367,6 @@ Array [
   },
 ]
 `;
-
-exports[`removeSourceNetwork removes all networks whose uid_ems matches that of the specified source network 1`] = `
-Object {
-  "allow_promiscuous": null,
-  "computed_allow_promiscuous": null,
-  "computed_forged_transmits": null,
-  "computed_mac_changes": null,
-  "created_on": "2017-06-01T04:24:18Z",
-  "forged_transmits": null,
-  "href": "http://localhost:3000/api/lans/10000000000019",
-  "id": "1-1",
-  "mac_changes": null,
-  "name": "RHV Cluster 1 - ovirtmgmt1",
-  "nodes": Array [
-    Object {
-      "allow_promiscuous": null,
-      "computed_allow_promiscuous": null,
-      "computed_forged_transmits": null,
-      "computed_mac_changes": null,
-      "created_on": "2017-06-01T04:24:18Z",
-      "forged_transmits": null,
-      "href": "http://localhost:3000/api/lans/10000000000009",
-      "id": "1-3",
-      "mac_changes": null,
-      "name": "VMWareCluster1-vm_network2",
-      "parent_id": null,
-      "switch_id": "1",
-      "tag": "24",
-      "uid_ems": "VMWareCluster1-vm_network2",
-      "updated_on": "2017-06-01T04:24:18Z",
-    },
-  ],
-  "parent_id": null,
-  "switch_id": "10000000000008",
-  "tag": null,
-  "uid_ems": "00000000-0000-0000-0000-000000000009",
-  "updated_on": "2017-06-01T04:24:18Z",
-}
-`;
-
-exports[`removeSourceNetwork returns null if no source networks remain 1`] = `null`;
-
-exports[`removeTargetNetwork removes the networks mapping for the specified target network 1`] = `
-Object {
-  "created_on": "2017-10-06T16:41:09Z",
-  "drs_automation_level": "fullyAutomated",
-  "drs_enabled": false,
-  "drs_migration_threshold": 3,
-  "effective_cpu": 109356,
-  "effective_memory": 790163881984,
-  "ems_id": "1",
-  "ems_ref": "domain-c7",
-  "ems_ref_obj": "domain-c7",
-  "ha_admit_control": true,
-  "ha_enabled": false,
-  "ha_max_failures": 1,
-  "href": "http://localhost:3000/api/clusters/1",
-  "id": "1",
-  "last_perf_capture_on": null,
-  "name": "RHV Cluster 1",
-  "nodes": Array [
-    Object {
-      "allow_promiscuous": null,
-      "computed_allow_promiscuous": null,
-      "computed_forged_transmits": null,
-      "computed_mac_changes": null,
-      "created_on": "2017-06-01T04:24:19Z",
-      "forged_transmits": null,
-      "href": "http://localhost:3000/api/lans/10000000000020",
-      "id": "1-2",
-      "mac_changes": null,
-      "name": "RHV Cluster 1 - ovirtmgmt2",
-      "nodes": Array [
-        Object {
-          "allow_promiscuous": null,
-          "computed_allow_promiscuous": null,
-          "computed_forged_transmits": null,
-          "computed_mac_changes": null,
-          "created_on": "2017-06-01T04:24:18Z",
-          "forged_transmits": null,
-          "href": "http://localhost:3000/api/lans/10000000000008",
-          "id": "1-2",
-          "mac_changes": null,
-          "name": "VMWareCluster1-vm_network1",
-          "parent_id": null,
-          "switch_id": "2",
-          "tag": "24",
-          "uid_ems": "VMWareCluster1-vm_network1",
-          "updated_on": "2017-06-01T04:24:18Z",
-        },
-      ],
-      "parent_id": null,
-      "switch_id": "10000000000015",
-      "tag": null,
-      "uid_ems": "00000000-0000-0000-0000-000000000009",
-      "updated_on": "2017-06-01T04:24:19Z",
-    },
-  ],
-  "type": null,
-  "uid_ems": "domain-c7",
-  "updated_on": "2018-01-20T23:12:00Z",
-}
-`;
-
-exports[`removeTargetNetwork returns null if no networks mappings remain 1`] = `null`;
 
 exports[`sourceNetworkWithTreeViewAttrs adds extra attributes for display in TreeView 1`] = `
 Object {

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/__tests__/helpers.test.js
@@ -7,8 +7,8 @@ import {
   networkGroupingForRep,
   dedupeMappedSourceNetworks,
   mappingsForTreeView,
-  removeTargetNetwork,
-  removeSourceNetwork
+  mappingWithTargetNetworkRemoved,
+  mappingWithSourceNetworkRemoved
 } from '../helpers';
 import { groupByUidEms } from '../../../MappingWizardNetworksStepSelectors';
 import {
@@ -97,7 +97,7 @@ test('mappingsForTreeView reduces source networks to representatives for all net
   expect(mappingsForTreeView([networksStepMapping])).toMatchSnapshot();
 });
 
-describe('removeTargetNetwork', () => {
+describe('mappingWithTargetNetworkRemoved', () => {
   const [targetNetworkToRemove, targetNetworkShouldRemain] = targetNetworks;
   const [sourceNetworkOne, sourceNetworkTwo] = sourceNetworks;
   const nodeToRemove = {
@@ -116,7 +116,10 @@ describe('removeTargetNetwork', () => {
     };
 
     expect(
-      removeTargetNetwork(networksStepMapping, targetNetworkToRemove)
+      mappingWithTargetNetworkRemoved(
+        networksStepMapping,
+        targetNetworkToRemove
+      )
     ).toMatchSnapshot();
   });
 
@@ -127,12 +130,15 @@ describe('removeTargetNetwork', () => {
     };
 
     expect(
-      removeTargetNetwork(networksStepMapping, targetNetworkToRemove)
+      mappingWithTargetNetworkRemoved(
+        networksStepMapping,
+        targetNetworkToRemove
+      )
     ).toMatchSnapshot();
   });
 });
 
-describe('removeSourceNetwork', () => {
+describe('mappingWithSourceNetworkRemoved', () => {
   const [, , sourceNetworkShouldRemain] = sourceNetworks;
   const [sourceNetworkToRemove] = networkGrouping;
   const [targetNetwork] = targetNetworks;
@@ -144,7 +150,7 @@ describe('removeSourceNetwork', () => {
     };
 
     expect(
-      removeSourceNetwork(networksMapping, sourceNetworkToRemove)
+      mappingWithSourceNetworkRemoved(networksMapping, sourceNetworkToRemove)
     ).toMatchSnapshot();
   });
 
@@ -155,7 +161,7 @@ describe('removeSourceNetwork', () => {
     };
 
     expect(
-      removeSourceNetwork(networksMapping, sourceNetworkToRemove)
+      mappingWithSourceNetworkRemoved(networksMapping, sourceNetworkToRemove)
     ).toMatchSnapshot();
   });
 });

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/__tests__/helpers.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/__tests__/helpers.test.js
@@ -6,7 +6,9 @@ import {
   sourceNetworkWithTreeViewAttrs,
   networkGroupingForRep,
   dedupeMappedSourceNetworks,
-  mappingsForTreeView
+  mappingsForTreeView,
+  removeTargetNetwork,
+  removeSourceNetwork
 } from '../helpers';
 import { groupByUidEms } from '../../../MappingWizardNetworksStepSelectors';
 import {
@@ -93,4 +95,67 @@ test('mappingsForTreeView reduces source networks to representatives for all net
   };
 
   expect(mappingsForTreeView([networksStepMapping])).toMatchSnapshot();
+});
+
+describe('removeTargetNetwork', () => {
+  const [targetNetworkToRemove, targetNetworkShouldRemain] = targetNetworks;
+  const [sourceNetworkOne, sourceNetworkTwo] = sourceNetworks;
+  const nodeToRemove = {
+    ...targetNetworkToRemove,
+    nodes: [sourceNetworkOne]
+  };
+
+  test('removes the networks mapping for the specified target network', () => {
+    const nodeShouldRemain = {
+      ...targetNetworkShouldRemain,
+      nodes: [sourceNetworkTwo]
+    };
+    const networksStepMapping = {
+      ...targetCluster,
+      nodes: [nodeToRemove, nodeShouldRemain]
+    };
+
+    expect(
+      removeTargetNetwork(networksStepMapping, targetNetworkToRemove)
+    ).toMatchSnapshot();
+  });
+
+  test('returns null if no networks mappings remain', () => {
+    const networksStepMapping = {
+      ...targetCluster,
+      nodes: [nodeToRemove]
+    };
+
+    expect(
+      removeTargetNetwork(networksStepMapping, targetNetworkToRemove)
+    ).toMatchSnapshot();
+  });
+});
+
+describe('removeSourceNetwork', () => {
+  const [, , sourceNetworkShouldRemain] = sourceNetworks;
+  const [sourceNetworkToRemove] = networkGrouping;
+  const [targetNetwork] = targetNetworks;
+
+  test('removes all networks whose uid_ems matches that of the specified source network', () => {
+    const networksMapping = {
+      ...targetNetwork,
+      nodes: [...networkGrouping, sourceNetworkShouldRemain]
+    };
+
+    expect(
+      removeSourceNetwork(networksMapping, sourceNetworkToRemove)
+    ).toMatchSnapshot();
+  });
+
+  test('returns null if no source networks remain', () => {
+    const networksMapping = {
+      ...targetNetwork,
+      nodes: [sourceNetworkToRemove]
+    };
+
+    expect(
+      removeSourceNetwork(networksMapping, sourceNetworkToRemove)
+    ).toMatchSnapshot();
+  });
 });

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/helpers.js
@@ -97,3 +97,30 @@ export const mappingsForTreeView = mappings =>
     };
     return [...updatedMappings, updatedMapping];
   }, []);
+
+export const removeTargetNetwork = (networksStepMapping, targetNetwork) => {
+  const { nodes: networksMappings, ...targetCluster } = networksStepMapping;
+  const updatedNetworksMappings = networksMappings.filter(
+    targetNetworkWithSourceNetworks =>
+      targetNetworkWithSourceNetworks.id !== targetNetwork.id
+  );
+  return updatedNetworksMappings.length === 0
+    ? null
+    : {
+        ...targetCluster,
+        nodes: updatedNetworksMappings
+      };
+};
+
+export const removeSourceNetwork = (networksMapping, sourceNetworkToRemove) => {
+  const { nodes: sourceNetworks, ...targetNetwork } = networksMapping;
+  const updatedSourceNetworks = sourceNetworks.filter(
+    sourceNetwork => sourceNetwork.uid_ems !== sourceNetworkToRemove.uid_ems
+  );
+  return updatedSourceNetworks.length === 0
+    ? null
+    : {
+        ...targetNetwork,
+        nodes: updatedSourceNetworks
+      };
+};

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/helpers.js
@@ -98,11 +98,14 @@ export const mappingsForTreeView = mappings =>
     return [...updatedMappings, updatedMapping];
   }, []);
 
-export const removeTargetNetwork = (networksStepMapping, targetNetwork) => {
+export const mappingWithTargetNetworkRemoved = (
+  networksStepMapping,
+  targetNetworkToRemove
+) => {
   const { nodes: networksMappings, ...targetCluster } = networksStepMapping;
   const updatedNetworksMappings = networksMappings.filter(
     targetNetworkWithSourceNetworks =>
-      targetNetworkWithSourceNetworks.id !== targetNetwork.id
+      targetNetworkWithSourceNetworks.id !== targetNetworkToRemove.id
   );
   return updatedNetworksMappings.length === 0
     ? null
@@ -112,7 +115,10 @@ export const removeTargetNetwork = (networksStepMapping, targetNetwork) => {
       };
 };
 
-export const removeSourceNetwork = (networksMapping, sourceNetworkToRemove) => {
+export const mappingWithSourceNetworkRemoved = (
+  networksMapping,
+  sourceNetworkToRemove
+) => {
   const { nodes: sourceNetworks, ...targetNetwork } = networksMapping;
   const updatedSourceNetworks = sourceNetworks.filter(
     sourceNetwork => sourceNetwork.uid_ems !== sourceNetworkToRemove.uid_ems


### PR DESCRIPTION
* Break down the method and improve readability by extracting pieces into helper functions
* Tests should also help support changes introduced in https://github.com/priley86/miq_v2v_ui_plugin/pull/149, specifically, by ensuring that when we remove a source network node from the TreeView, that it's entire grouping gets removed from the data mapping

# Note
First commit is to fix some tests that were passing due to collision of non-unique ids