### PR TITLE
Prevent login modal in the Migration screen

### DIFF
--- a/app/javascript/common/API.js
+++ b/app/javascript/common/API.js
@@ -1,13 +1,10 @@
 import axios from 'axios';
 
-const getcsrfToken = () => {
-  const token = document.querySelector('meta[name="csrf-token"]');
-
-  return token ? token.content : '';
-};
+const getAuthToken = () =>
+  localStorage.miq_token ? localStorage.miq_token : '';
 
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
-axios.defaults.headers.common['X-CSRF-Token'] = getcsrfToken();
+axios.defaults.headers.common['X-Auth-Token'] = getAuthToken();
 
 export default {
   get(url, headers = {}, params = {}) {

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/__snapshots__/MappingWizardClusterStepActions.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/__snapshots__/MappingWizardClusterStepActions.test.js.snap
@@ -12,7 +12,7 @@ Array [
         "data": undefined,
         "headers": Object {
           "Accept": "application/json, text/plain, */*",
-          "X-CSRF-Token": "",
+          "X-Auth-Token": "",
           "X-Requested-With": "XMLHttpRequest",
         },
         "maxContentLength": -1,
@@ -64,7 +64,7 @@ Array [
         "data": undefined,
         "headers": Object {
           "Accept": "application/json, text/plain, */*",
-          "X-CSRF-Token": "",
+          "X-Auth-Token": "",
           "X-Requested-With": "XMLHttpRequest",
         },
         "maxContentLength": -1,

--- a/localStorageMock.js
+++ b/localStorageMock.js
@@ -1,0 +1,18 @@
+// localStorageMock.js
+const localStorageMock = (function() {
+  let store = {};
+
+  return {
+    getItem: key => store[key] || null,
+    setItem: (key, value) => {
+      store[key] = value.toString();
+    },
+    clear: () => {
+      store = {};
+    }
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock
+});

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "jest": {
     "setupFiles": [
       "raf/polyfill",
-      "./.jest-setup.js"
+      "./.jest-setup.js", "./localStorageMock.js"
     ],
     "moduleNameMapper": {
       "^.+\\.(png|gif|css|scss)$": "identity-obj-proxy"


### PR DESCRIPTION
Assign the persisted Auth Token from localStorage to `axios` headers to prevent login modal in the Migration screen.

Fixes https://github.com/priley86/miq_v2v_ui_plugin/issues/162