### PR TITLE
Added VM Selection Choice Radiobuttons in PlanWizard General Step

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/__tests__/__snapshots__/index.test.js.snap
@@ -9,6 +9,7 @@ Object {
   "planWizardGeneralStep": Object {
     "initial": Object {
       "infrastructure_mapping": undefined,
+      "vm_choice_radio": "vms_via_discovery",
     },
     "registeredFields": Object {
       "description": Object {
@@ -26,6 +27,11 @@ Object {
         "name": "name",
         "type": "Field",
       },
+      "vm_choice_radio": Object {
+        "count": 3,
+        "name": "vm_choice_radio",
+        "type": "Field",
+      },
     },
     "syncErrors": Object {
       "infrastructure_mapping": "Required",
@@ -33,6 +39,7 @@ Object {
     },
     "values": Object {
       "infrastructure_mapping": undefined,
+      "vm_choice_radio": "vms_via_discovery",
     },
   },
   "setPlansBodyAction": [Function],

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardGeneralStep/PlanWizardGeneralStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardGeneralStep/PlanWizardGeneralStep.js
@@ -34,6 +34,24 @@ const PlanWizardGeneralStep = ({ transformationMappings }) => (
       component={FormField}
       type="textarea"
     />
+    <Field
+      name="vm_choice_radio"
+      label={__('Select VMs')}
+      component={FormField}
+      type="radio"
+      options={[
+        {
+          name: __('Import a CSV file with a list of VMs to be migrated'),
+          id: 'vms_via_csv'
+        },
+        {
+          name: __(
+            'Choose from a list of VMs discovered in the selected infrastructure mapping'
+          ),
+          id: 'vms_via_discovery'
+        }
+      ]}
+    />
   </Form>
 );
 

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardGeneralStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardGeneralStep/index.js
@@ -3,7 +3,10 @@ import PlanWizardGeneralStep from './PlanWizardGeneralStep';
 
 const mapStateToProps = ({ overview }) => ({
   transformationMappings: overview.transformationMappings,
-  initialValues: { infrastructure_mapping: overview.planWizardId }
+  initialValues: {
+    infrastructure_mapping: overview.planWizardId,
+    vm_choice_radio: 'vms_via_discovery'
+  }
 });
 
 export default connect(mapStateToProps)(PlanWizardGeneralStep);

--- a/app/javascript/react/screens/App/common/forms/FormField.js
+++ b/app/javascript/react/screens/App/common/forms/FormField.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Form, Grid } from 'patternfly-react';
+import { Field } from 'redux-form';
 
 export const FormField = ({
   input,
@@ -15,6 +16,8 @@ export const FormField = ({
   ...props
 }) => {
   const formGroupProps = { key: { label }, controlId, ...props };
+
+  const addBreak = <br />;
 
   if (touched && error) formGroupProps.validationState = 'error';
 
@@ -41,6 +44,22 @@ export const FormField = ({
           </select>
         );
         break;
+      case 'radio':
+        field = options.map(val => (
+          <div key={val.id}>
+            <label htmlFor={input.name}>
+              <Field
+                name={input.name}
+                component="input"
+                type="radio"
+                value={val.id}
+              />
+              {` ${val.name}`}
+            </label>
+            <br />
+          </div>
+        ));
+        break;
       default:
     }
     return field;
@@ -53,6 +72,7 @@ export const FormField = ({
         {required && ' *'}
       </Grid.Col>
       <Grid.Col sm={9}>
+        {type === 'radio' && addBreak}
         {renderField()}
         {touched && error && <Form.HelpBlock>{error}</Form.HelpBlock>}
       </Grid.Col>


### PR DESCRIPTION
- Added Support for Radiobuttons to `FormField` (our component for `redux-form` based fields)
- Added VM Selection choice Radiobuttons to PlanWizard Step1
- Set default selection to `vms_via_discovery`

Screenshot -

<img width="816" alt="screen shot 2018-03-28 at 1 39 35 pm" src="https://user-images.githubusercontent.com/1538216/38055185-ded9a692-328d-11e8-8b2b-a602f95830ca.png">
