### PR TITLE
Overview empty states

### DIFF
--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { bindMethods, CardGrid } from 'patternfly-react';
+import { bindMethods, CardGrid, Spinner } from 'patternfly-react';
 import * as AggregateCards from './components/AggregateCards';
 import InfrastructureMappingsList from './components/InfrastructureMappingsList/InfrastructureMappingsList';
 import Migrations from './components/Migrations/Migrations';
@@ -146,22 +146,19 @@ class Overview extends React.Component {
         style={{ overflow: 'auto', paddingBottom: 1, height: '100%' }}
       >
         {aggregateDataCards}
-
-        {!isFetchingTransformationPlans &&
-          !isFetchingTransformationMappings &&
-          transformationMappings.length > 0 && (
-            <Migrations
-              transformationPlans={transformationPlans}
-              createMigrationPlanClick={showPlanWizardAction}
-            />
-          )}
-
-        {!isFetchingTransformationMappings && (
+        <Spinner loading={isFetchingTransformationMappings}>
+          {!isFetchingTransformationPlans &&
+            transformationMappings.length > 0 && (
+              <Migrations
+                transformationPlans={transformationPlans}
+                createMigrationPlanClick={showPlanWizardAction}
+              />
+            )}
           <InfrastructureMappingsList
             transformationMappings={transformationMappings}
             createInfraMappingClick={showMappingWizardAction}
           />
-        )}
+        </Spinner>
       </div>
     );
 

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -147,10 +147,12 @@ class Overview extends React.Component {
 
         <Migrations createMigrationPlanClick={showPlanWizardAction} />
 
-        <InfrastructureMappingsList
-          transformationMappings={transformationMappings}
-          createInfraMappingClick={showMappingWizardAction}
-        />
+        {!isFetchingTransformationMappings && (
+          <InfrastructureMappingsList
+            transformationMappings={transformationMappings}
+            createInfraMappingClick={showMappingWizardAction}
+          />
+        )}
       </div>
     );
 

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -105,12 +105,14 @@ class Overview extends React.Component {
   render() {
     const {
       showMappingWizardAction,
-      showPlanWizardAction, // eslint-disable-line no-unused-vars
+      showPlanWizardAction,
       mappingWizardVisible,
       planWizardVisible,
-      transformationMappings, // eslint-disable-line no-unused-vars
-      isFetchingTransformationMappings, // eslint-disable-line no-unused-vars
-      isRejectedTransformationMappings // eslint-disable-line no-unused-vars
+      transformationMappings,
+      isFetchingTransformationMappings,
+      isRejectedTransformationMappings, // eslint-disable-line no-unused-vars
+      transformationPlans,
+      isFetchingTransformationPlans
     } = this.props;
 
     const aggregateDataCards = (
@@ -145,7 +147,14 @@ class Overview extends React.Component {
       >
         {aggregateDataCards}
 
-        <Migrations createMigrationPlanClick={showPlanWizardAction} />
+        {!isFetchingTransformationPlans &&
+          !isFetchingTransformationMappings &&
+          transformationMappings.length > 0 && (
+            <Migrations
+              transformationPlans={transformationPlans}
+              createMigrationPlanClick={showPlanWizardAction}
+            />
+          )}
 
         {!isFetchingTransformationMappings && (
           <InfrastructureMappingsList
@@ -180,6 +189,8 @@ Overview.propTypes = {
   transformationMappings: PropTypes.array,
   isFetchingTransformationMappings: PropTypes.bool,
   isRejectedTransformationMappings: PropTypes.bool,
+  transformationPlans: PropTypes.array,
+  isFetchingTransformationPlans: PropTypes.bool,
   isContinuingToPlan: PropTypes.bool,
   planWizardId: PropTypes.string,
   continueToPlanAction: PropTypes.func,

--- a/app/javascript/react/screens/App/Overview/__test__/Overview.test.js
+++ b/app/javascript/react/screens/App/Overview/__test__/Overview.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import Overview from '../Overview';
 import { coreComponents } from '../../../../../components';
 import componentRegistry from '../../../../../components/componentRegistry';
+import { transformationMappings } from '../overview.fixtures';
 
 jest.mock('../../../../../components/componentRegistry');
 jest.useFakeTimers();
@@ -32,6 +33,43 @@ describe('Overview component', () => {
     fetchTransformationMappingsAction = jest.fn();
     fetchTransformationPlanRequestsAction = jest.fn();
     fetchTransformationPlansAction = jest.fn();
+  });
+
+  describe('overview sections', () => {
+    test('does not render Migrations if there are no transformation mappings', () => {
+      const wrapper = shallow(
+        <Overview
+          {...baseProps}
+          showMappingWizardAction={showMappingWizardAction}
+          showPlanWizardAction={showPlanWizardAction}
+          fetchTransformationMappingsAction={fetchTransformationMappingsAction}
+          fetchTransformationPlanRequestsAction={
+            fetchTransformationPlanRequestsAction
+          }
+          fetchTransformationPlansAction={fetchTransformationPlansAction}
+        />
+      );
+
+      expect(wrapper.find('Migrations').exists()).toBe(false);
+    });
+
+    test('renders Migrations if there are transformation mappings', () => {
+      const wrapper = shallow(
+        <Overview
+          {...baseProps}
+          transformationMappings={transformationMappings}
+          showMappingWizardAction={showMappingWizardAction}
+          showPlanWizardAction={showPlanWizardAction}
+          fetchTransformationMappingsAction={fetchTransformationMappingsAction}
+          fetchTransformationPlanRequestsAction={
+            fetchTransformationPlanRequestsAction
+          }
+          fetchTransformationPlansAction={fetchTransformationPlansAction}
+        />
+      );
+
+      expect(wrapper.find('Migrations').exists()).toBe(true);
+    });
   });
 
   describe('polling', () => {

--- a/app/javascript/react/screens/App/Overview/__test__/Overview.test.js
+++ b/app/javascript/react/screens/App/Overview/__test__/Overview.test.js
@@ -18,7 +18,8 @@ describe('Overview component', () => {
     isRejectedTransformationMappings: false,
     isFetchingTransformationPlanRequests: false,
     isRejectedTransformationPlanRequests: false,
-    errorTransformationPlanRequests: null
+    errorTransformationPlanRequests: null,
+    transformationMappings: []
   };
   let showMappingWizardAction;
   let showPlanWizardAction;

--- a/app/javascript/react/screens/App/Overview/components/InfrastructureMappingsList/InfrastructureMappingsList.js
+++ b/app/javascript/react/screens/App/Overview/components/InfrastructureMappingsList/InfrastructureMappingsList.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Icon, ListView, Grid } from 'patternfly-react';
+import OverviewEmptyState from '../OverviewEmptyState/OverviewEmptyState';
 
 const InfrastructureMappingsList = ({
   transformationMappings,
@@ -9,56 +10,65 @@ const InfrastructureMappingsList = ({
   <Grid.Col
     xs={12}
     style={{
-      backgroundColor: '#fff',
       paddingBottom: 100,
       height: '100%'
     }}
   >
-    <div className="heading-with-link-container">
-      <div className="pull-left">
-        <h3>{__('Infrastructure Mappings')}</h3>
-      </div>
-      <div className="pull-right">
-        {/** todo: create IconLink in patternfly-react * */}
-        <a
-          href="#"
-          onClick={e => {
-            e.preventDefault();
-            createInfraMappingClick();
-          }}
-        >
-          <Icon type="pf" name="add-circle-o" />
-          &nbsp;{__('Create Infrastructure Mapping')}
-        </a>
-      </div>
-    </div>
-
-    <ListView>
-      {transformationMappings.map(mapping => (
-        <ListView.Item
-          key={mapping.id}
-          heading={mapping.name}
-          description={mapping.description}
-          additionalInfo={[
-            <ListView.InfoItem key={0}>
-              <Icon type="pf" name="cluster" />
-              <strong>2</strong>&nbsp;{__('Source Clusters')}
-            </ListView.InfoItem>,
-            <ListView.InfoItem key={1}>
-              <Icon type="pf" name="cluster" />
-              <strong>2</strong>&nbsp;{__('Target Clusters')}
-            </ListView.InfoItem>
-          ]}
-        >
-          <Grid.Row>
-            <Grid.Col sm={11}>
-              Lorem Ipsum is simply dummy text of the printing and typesetting
-              industry
-            </Grid.Col>
-          </Grid.Row>
-        </ListView.Item>
-      ))}
-    </ListView>
+    {transformationMappings.length > 0 ? (
+      <React.Fragment>
+        <div className="heading-with-link-container">
+          <div className="pull-left">
+            <h3>{__('Infrastructure Mappings')}</h3>
+          </div>
+          <div className="pull-right">
+            {/** todo: create IconLink in patternfly-react * */}
+            <a
+              href="#"
+              onClick={e => {
+                e.preventDefault();
+                createInfraMappingClick();
+              }}
+            >
+              <Icon type="pf" name="add-circle-o" />
+              &nbsp;{__('Create Infrastructure Mapping')}
+            </a>
+          </div>
+        </div>
+        <hr style={{ borderTopColor: '#d1d1d1' }} />
+        <ListView>
+          {transformationMappings.map(mapping => (
+            <ListView.Item
+              key={mapping.id}
+              heading={mapping.name}
+              description={mapping.description}
+              additionalInfo={[
+                <ListView.InfoItem key={0}>
+                  <Icon type="pf" name="cluster" />
+                  <strong>2</strong>&nbsp;{__('Source Clusters')}
+                </ListView.InfoItem>,
+                <ListView.InfoItem key={1}>
+                  <Icon type="pf" name="cluster" />
+                  <strong>2</strong>&nbsp;{__('Target Clusters')}
+                </ListView.InfoItem>
+              ]}
+            >
+              <Grid.Row>
+                <Grid.Col sm={11}>
+                  Lorem Ipsum is simply dummy text of the printing and
+                  typesetting industry
+                </Grid.Col>
+              </Grid.Row>
+            </ListView.Item>
+          ))}
+        </ListView>
+      </React.Fragment>
+    ) : (
+      <OverviewEmptyState
+        showWizardAction={createInfraMappingClick}
+        description="Create an infrastructure mapping to later be used by a migration plan."
+        buttonText="Create Infrastructure Mapping"
+      />
+    )}
   </Grid.Col>
 );
 

--- a/app/javascript/react/screens/App/Overview/components/InfrastructureMappingsList/__test__/InfrastructureMappingList.test.js
+++ b/app/javascript/react/screens/App/Overview/components/InfrastructureMappingsList/__test__/InfrastructureMappingList.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import InfrastructureMappingsList from '../InfrastructureMappingsList';
+
+let createInfraMappingClick;
+beforeEach(() => {
+  createInfraMappingClick = jest.fn();
+});
+
+test('it shows the empty state when there are no transformation mappings', () => {
+  const wrapper = shallow(
+    <InfrastructureMappingsList
+      transformationMappings={[]}
+      createInfraMappingClick={createInfraMappingClick}
+    />
+  );
+
+  expect(wrapper.find('OverviewEmptyState').exists()).toBe(true);
+});

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -4,6 +4,7 @@ import { noop, DropdownButton, Grid, Icon, MenuItem } from 'patternfly-react';
 import MigrationsInProgressCard from '../Cards/MigrationsInProgressCard';
 import MigrationsNotStartedList from './MigrationsNotStartedList';
 import MigrationsCompletedList from './MigrationsCompletedList';
+import OverviewEmptyState from '../OverviewEmptyState/OverviewEmptyState';
 
 class Migrations extends React.Component {
   constructor(props) {
@@ -16,7 +17,7 @@ class Migrations extends React.Component {
     this.setState({ activeFilter: eventKey });
   };
   render() {
-    const { createMigrationPlanClick } = this.props;
+    const { transformationPlans, createMigrationPlanClick } = this.props;
     const { activeFilter } = this.state;
     const filterOptions = [
       'Migration Plans Not Started',
@@ -46,39 +47,52 @@ class Migrations extends React.Component {
             </div>
           </div>
           <hr style={{ borderTopColor: '#d1d1d1' }} />
-          <div style={{ marginBottom: 15 }}>
-            <DropdownButton
-              bsStyle="default"
-              title={sprintf('%s', activeFilter)}
-              id="dropdown-filter"
-              onSelect={this.onSelect}
-            >
-              {filterOptions.map((filter, i) => (
-                <MenuItem
-                  eventKey={filter}
-                  active={filter === activeFilter}
-                  key={i}
-                >
-                  {sprintf('%s', filter)}
-                </MenuItem>
-              ))}
-            </DropdownButton>
-          </div>
+          {transformationPlans.length > 0 ? (
+            <div style={{ marginBottom: 15 }}>
+              <DropdownButton
+                bsStyle="default"
+                title={sprintf('%s', activeFilter)}
+                id="dropdown-filter"
+                onSelect={this.onSelect}
+              >
+                {filterOptions.map((filter, i) => (
+                  <MenuItem
+                    eventKey={filter}
+                    active={filter === activeFilter}
+                    key={i}
+                  >
+                    {sprintf('%s', filter)}
+                  </MenuItem>
+                ))}
+              </DropdownButton>
+            </div>
+          ) : (
+            <OverviewEmptyState
+              showWizardAction={createMigrationPlanClick}
+              description="Create a migration plan to select VMs for migration."
+              buttonText="Create Migration Plan"
+            />
+          )}
         </Grid.Col>
-        {activeFilter === 'Migration Plans Not Started' && (
-          <MigrationsNotStartedList />
-        )}
-        {activeFilter === 'Migration Plans in Progress' && (
-          <MigrationsInProgressCard />
-        )}
-        {activeFilter === 'Migration Plans Completed' && (
-          <MigrationsCompletedList />
+        {transformationPlans.length > 0 && (
+          <React.Fragment>
+            {activeFilter === 'Migration Plans Not Started' && (
+              <MigrationsNotStartedList />
+            )}
+            {activeFilter === 'Migration Plans in Progress' && (
+              <MigrationsInProgressCard />
+            )}
+            {activeFilter === 'Migration Plans Completed' && (
+              <MigrationsCompletedList />
+            )}
+          </React.Fragment>
         )}
       </React.Fragment>
     );
   }
 }
 Migrations.propTypes = {
+  transformationPlans: PropTypes.array,
   createMigrationPlanClick: PropTypes.func
 };
 Migrations.defaultProps = {

--- a/app/javascript/react/screens/App/Overview/components/Migrations/__test__/Migrations.test.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/__test__/Migrations.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Migrations from '../Migrations';
+
+let createMigrationPlanClick;
+beforeEach(() => {
+  createMigrationPlanClick = jest.fn();
+});
+
+test('shows the empty state when there are no transformation plans', () => {
+  const wrapper = shallow(
+    <Migrations
+      transformationMappingsExist
+      transformationPlans={[]}
+      createMigrationPlanClick={createMigrationPlanClick}
+    />
+  );
+
+  expect(wrapper.find('OverviewEmptyState').exists()).toBe(true);
+});

--- a/app/javascript/react/screens/App/Overview/components/OverviewEmptyState/OverviewEmptyState.js
+++ b/app/javascript/react/screens/App/Overview/components/OverviewEmptyState/OverviewEmptyState.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, EmptyState } from 'patternfly-react';
+
+const OverviewEmptyState = ({ showWizardAction, description, buttonText }) => (
+  <div className="blank-slate-pf">
+    <EmptyState.Icon />
+    <EmptyState.Title>&nbsp;</EmptyState.Title>
+    <EmptyState.Info>{sprintf(__('%s'), description)}</EmptyState.Info>
+    <EmptyState.Action>
+      <Button bsStyle="primary" bsSize="large" onClick={showWizardAction}>
+        {sprintf(__('%s'), buttonText)}
+      </Button>
+    </EmptyState.Action>
+  </div>
+);
+
+OverviewEmptyState.propTypes = {
+  showWizardAction: PropTypes.func,
+  description: PropTypes.string,
+  buttonText: PropTypes.string
+};
+
+export default OverviewEmptyState;


### PR DESCRIPTION
* Creates empty state component for Overview
* Adds loading state for Migrations and Infra Mappings section below agg cards

## Notes
1. The empty state for the infrastructures mapping list will only show when there are no `transformationMappings`.
2. The empty state for the migrations section will only show when there are no `transformationPlans`
3. Loading state is based on `isFetchingTransformationMappings` (aka "Infrastructure Mappings")
    * In theory, a `transformationPlan` (aka "Migration Plan") or `transformationRequest` cannot exist until a `transformationMapping` exists
4. Loading state UX could be improved, but might be better to wait for the UI to get further fleshed out.  Things might get complicated when we start taking the polling behavior into consideration

## No Transformation Mappings
<img width="1920" alt="no-transformation-mappings" src="https://user-images.githubusercontent.com/15141412/38423484-0ce0e114-397c-11e8-8582-9e114e8c6bc6.png">

## Transformation Mappings Exist, No Transformation Plans
<img width="1920" alt="transformation-mappings-exist-no-transformation-plans" src="https://user-images.githubusercontent.com/15141412/38423513-23157788-397c-11e8-8cd3-8c148969e63d.png">

## Loading State 1
![loading-state-1](https://user-images.githubusercontent.com/15141412/38423838-0c7292d0-397d-11e8-8aaf-0e78fad8354a.gif)

## Loading State 2
![loading-state-2](https://user-images.githubusercontent.com/15141412/38424114-ffcf9d1a-397d-11e8-98dc-30c41c5270af.gif)

## Loading State 3
![loading-state-3](https://user-images.githubusercontent.com/15141412/38424043-cbe8ad16-397d-11e8-83a5-9e5c393dc3a8.gif)

