### PR TITLE
Create new advanced settings flag to enable/disable v2v migration in the Ops UI

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # MiqV2vUI::Engine.routes.draw do
-Rails.application.routes.draw do
-  match '/migration' => 'migration#index', :via => [:get]
-  match 'migration/*page' => 'migration#index', :via => [:get]
+if ::Settings.product.transformation == true
+  Rails.application.routes.draw do
+    match '/migration' => 'migration#index', :via => [:get]
+    match 'migration/*page' => 'migration#index', :via => [:get]
+  end
 end

--- a/lib/miq_v2v_ui/engine.rb
+++ b/lib/miq_v2v_ui/engine.rb
@@ -10,13 +10,15 @@ module MiqV2vUI
       app.config.assets.paths << root.join('assets', 'images').to_s
     end
 
-    initializer 'plugin' do
-      Menu::CustomLoader.register(
-        Menu::Section.new(:migration, N_("Migration"), 'fa fa-plus', [
+    def renderMigrationMenu
+      Menu::Section.new(:migration, N_("Migration"), 'fa fa-plus', [
           Menu::Item.new('overview', N_('Overview'), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration'),
           Menu::Item.new('infrastructure_mappings', N_('Infrastructure Mappings'), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration/infrastructure-mappings')
-        ], nil, nil, nil, nil, :compute),
-      )
+      ], nil, nil, nil, nil, :compute)
+    end
+
+    initializer 'plugin' do
+      Menu::CustomLoader.register(::Settings.product.transformation == true ? renderMigrationMenu : nil)
     end
   end
 end


### PR DESCRIPTION
The Advanced Settings flag is `transformation` which should be placed directly under the `product` section in the yaml as shown below -

<img width="326" alt="screen shot 2018-04-09 at 1 35 22 pm" src="https://user-images.githubusercontent.com/1538216/38521558-eb04748a-3bfa-11e8-8e75-80fe85f57d5c.png">

----------

To enable v2v UI --
```yaml
:transformation: true
```
--------

To disable v2v UI --
```yaml
:transformation: false
```

or

Do not specify the`:transformation` flag in the yaml

--------



https://bugzilla.redhat.com/show_bug.cgi?id=1565328