### PR TITLE
Sort completed migrations and in-progress migrations by descending date

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedActions.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedActions.js
@@ -26,7 +26,8 @@ const fetchMigrationsCompletedAction = () => {
     "filter[]=state='finished'" +
     "&filter[]=type='ServiceTemplateTransformationPlanRequest'" +
     '&expand=resources' +
-    '&attributes=status,state,options,description,miq_request_tasks';
+    '&attributes=status,state,options,description,miq_request_tasks' +
+    '&sort_by=updated_on';
 
   const uri = new URI(url);
 

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/MigrationsInProgressActions.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsInProgressCard/MigrationsInProgressActions.js
@@ -26,7 +26,8 @@ const fetchMigrationsInProgressAction = () => {
     "filter[]=state='active'" +
     "&filter[]=type='ServiceTemplateTransformationPlanRequest'" +
     '&expand=resources' +
-    '&attributes=status,state,options,description,miq_request_tasks';
+    '&attributes=status,state,options,description,miq_request_tasks' +
+    '&sort_by=updated_on';
 
   const uri = new URI(url);
 


### PR DESCRIPTION
Added `sort_by=updated_on` parameter to the API request to sort the list in descending order by date

Fixes https://github.com/priley86/miq_v2v_ui_plugin/issues/184

https://bugzilla.redhat.com/show_bug.cgi?id=1565021

Screenshot below shows the time elapsed sorted in descending order -
<img width="1079" alt="screen shot 2018-04-12 at 2 28 43 pm" src="https://user-images.githubusercontent.com/1538216/38705273-df982492-3e5d-11e8-83a6-e0e908ccea24.png">
