### PR TITLE
Migrations completed

### DIFF
--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -102,7 +102,7 @@ export const coreComponents = [
         : '/api/service_templates/?' +
           "filter[]=type='ServiceTemplateTransformationPlan'" +
           '&expand=resources' +
-          '&attributes=miq_requests'
+          '&attributes=miq_requests,created_on,updated_on'
     },
     store: true
   },

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -156,11 +156,17 @@ class Overview extends React.Component {
         style={{ overflow: 'auto', paddingBottom: 1, height: '100%' }}
       >
         {aggregateDataCards}
-        <Spinner loading={isFetchingTransformationMappings}>
+        <Spinner
+          loading={
+            isFetchingTransformationMappings ||
+            (isFetchingTransformationPlans && !plansPreviouslyFetched)
+          }
+        >
           {transformationMappings.length > 0 && (
             <Migrations
               transformationPlans={transformationPlans}
               createMigrationPlanClick={showPlanWizardAction}
+              finishedTransformationPlans={finishedTransformationPlans}
             />
           )}
           <InfrastructureMappingsList

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -16,8 +16,13 @@ class Migrations extends React.Component {
   onSelect = eventKey => {
     this.setState({ activeFilter: eventKey });
   };
+  retryClick = id => {};
   render() {
-    const { transformationPlans, createMigrationPlanClick } = this.props;
+    const {
+      transformationPlans,
+      createMigrationPlanClick,
+      finishedTransformationPlans
+    } = this.props;
     const { activeFilter } = this.state;
     const filterOptions = [
       'Migration Plans Not Started',
@@ -83,7 +88,10 @@ class Migrations extends React.Component {
               <MigrationsInProgressCard />
             )}
             {activeFilter === 'Migration Plans Completed' && (
-              <MigrationsCompletedList />
+              <MigrationsCompletedList
+                finishedTransformationPlans={finishedTransformationPlans}
+                retryClick={this.retryClick}
+              />
             )}
           </React.Fragment>
         )}
@@ -93,9 +101,12 @@ class Migrations extends React.Component {
 }
 Migrations.propTypes = {
   transformationPlans: PropTypes.array,
-  createMigrationPlanClick: PropTypes.func
+  createMigrationPlanClick: PropTypes.func,
+  finishedTransformationPlans: PropTypes.array
 };
 Migrations.defaultProps = {
-  createMigrationPlanClick: noop
+  transformationPlans: [],
+  createMigrationPlanClick: noop,
+  finishedTransformationPlans: []
 };
 export default Migrations;

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -1,52 +1,89 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop, Button, ListView, Grid } from 'patternfly-react';
+import { IsoElpasedTime } from '../../../../../../components/dates/IsoElapsedTime';
 
-const MigrationsCompletedList = ({ retryClick }) => (
+const MigrationsCompletedList = ({
+  finishedTransformationPlans,
+  retryClick
+}) => (
   <Grid.Col xs={12}>
     <ListView style={{ marginTop: 0 }}>
-      <ListView.Item
-        actions={<div />}
-        leftContent={
-          <ListView.Icon
-            type="pf"
-            name="ok"
-            size="md"
-            className="list-view-pf-icon-success"
+      {finishedTransformationPlans.map(plan => {
+        const [mostRecentRequest] = plan.miq_requests.slice(-1);
+        const failed = mostRecentRequest.status === 'failed';
+
+        const tasks = {};
+        plan.miq_requests.forEach(request => {
+          request.miq_request_tasks.forEach(task => {
+            tasks[task.options.src_id] = task.status === 'Ok';
+          });
+        });
+
+        let succeedCount = 0;
+        Object.values(tasks).forEach(value => {
+          if (value) succeedCount += 1;
+        });
+
+        const elapsedTime = IsoElpasedTime(
+          new Date(mostRecentRequest.created_on),
+          new Date(mostRecentRequest.updated_on)
+        );
+
+        return (
+          <ListView.Item
+            key={plan.id}
+            leftContent={
+              <ListView.Icon
+                type="pf"
+                name={failed ? 'error-circle-o' : 'ok'}
+                size="md"
+                style={{ width: 'inherit', backgroundColor: 'transparent' }}
+              />
+            }
+            heading={plan.name}
+            additionalInfo={[
+              <ListView.InfoItem
+                key={`${plan.id}-migrated`}
+                style={{ paddingRight: 40 }}
+              >
+                <ListView.Icon type="pf" size="lg" name="screen" />&nbsp;<strong
+                >
+                  {succeedCount}
+                </strong>{' '}
+                {__('of')} &nbsp;<strong>{Object.keys(tasks).length} </strong>
+                {__('VMs successfully migrated.')}
+              </ListView.InfoItem>,
+              <ListView.InfoItem key={`${plan.id}-elapsed`}>
+                <ListView.Icon type="fa" size="lg" name="clock-o" />
+                {elapsedTime}
+              </ListView.InfoItem>
+            ]}
+            actions={
+              (failed && (
+                <Button
+                  onClick={() => {
+                    retryClick(plan.id);
+                  }}
+                >
+                  Retry
+                </Button>
+              )) ||
+              (!failed && <div style={{ width: 50 }} />)
+            }
           />
-        }
-        heading="Migration Plan 1"
-        description="This item finished successfully."
-      >
-        More content.
-      </ListView.Item>
-      <ListView.Item
-        actions={
-          <div>
-            <Button onClick={retryClick}>Retry</Button>
-          </div>
-        }
-        leftContent={
-          <ListView.Icon
-            type="pf"
-            name="error-circle-o"
-            size="md"
-            className="list-view-pf-icon-danger"
-          />
-        }
-        heading="Migration Plan 2"
-        description="This item failed."
-      >
-        More content.
-      </ListView.Item>
+        );
+      })}
     </ListView>
   </Grid.Col>
 );
 
 MigrationsCompletedList.propTypes = {
+  finishedTransformationPlans: PropTypes.array,
   retryClick: PropTypes.func
 };
 MigrationsCompletedList.defaultProps = {
+  finishedTransformationPlans: [],
   retryClick: noop
 };
 

--- a/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
+++ b/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
@@ -56,6 +56,8 @@ export const transformationPlans = Immutable({
             delivered_on: '2018-01-30T21:12:34.808Z', // can use this timestamp as the starting time for this request
             user_message: '[EVM] VM Migrated Successfully'
           },
+          created_on: '2018-04-06T12:31:30Z',
+          updated_on: '2018-04-06T12:49:30Z',
           miq_request_tasks: [
             {
               created_on: '2018-04-06T12:31:30Z',
@@ -480,6 +482,8 @@ export const transformationPlans = Immutable({
           state: '',
           approval_state: 'approved',
           status: 'failed',
+          created_on: '2018-04-06T12:31:30Z',
+          updated_on: '2018-04-06T12:49:30Z',
           options: {
             src_id: '6',
             cart_state: 'ordered',
@@ -692,6 +696,8 @@ export const transformationPlans = Immutable({
           state: '',
           approval_state: 'approved',
           status: 'active',
+          created_on: '2018-04-06T12:31:30Z',
+          updated_on: '2018-04-06T12:49:30Z',
           options: {
             src_id: '6',
             cart_state: 'ordered',
@@ -925,6 +931,8 @@ export const transformationPlans = Immutable({
           state: '',
           approval_state: 'approved',
           status: 'failed',
+          created_on: '2018-04-06T12:31:30Z',
+          updated_on: '2018-04-06T12:49:30Z',
           options: {
             src_id: '6',
             cart_state: 'ordered',
@@ -1354,6 +1362,8 @@ export const transformationPlans = Immutable({
           state: '',
           approval_state: 'approved',
           status: 'complete',
+          created_on: '2018-04-06T12:31:30Z',
+          updated_on: '2018-04-06T12:49:30Z',
           options: {
             src_id: '6',
             cart_state: 'ordered',
@@ -1783,6 +1793,8 @@ export const transformationPlans = Immutable({
           state: '',
           approval_state: 'approved',
           status: 'active',
+          created_on: '2018-04-06T12:31:30Z',
+          updated_on: '2018-04-06T12:49:30Z',
           options: {
             src_id: '6',
             cart_state: 'ordered',

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -22,7 +22,9 @@ class Plan extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = { planRequestTasksMutable: [] };
+    this.state = {
+      planRequestTasksMutable: Immutable.asMutable(props.planRequestTasks)
+    };
 
     bindMethods(this, ['stopPolling', 'startPolling']);
   }


### PR DESCRIPTION
Helps closes out #151 

* wires up finished plans to the Migrations Completed list view of Overview
* aggregates/counts the successful/failed VMs across requests
* shows the status icons based on the last request
* shows the elapsed time based on the last request

Still need to wire up the "retry" button - working on that next...but this one is nearly done. 

thoughts @serenamarie125 @vconzola ?

<img width="1435" alt="screen shot 2018-04-13 at 8 07 55 am" src="https://user-images.githubusercontent.com/4237045/38734099-5c5fdcec-3ef2-11e8-8623-120af4d9d502.png">

