### PR TITLE
Disable Back button in Plan Wizard Results Step

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js
@@ -134,7 +134,7 @@ class PlanWizard extends React.Component {
             <Button
               bsStyle="default"
               onClick={this.prevStep}
-              disabled={onFirstStep}
+              disabled={onFirstStep || onFinalStep}
             >
               <Icon type="fa" name="angle-left" />
               {__('Back')}


### PR DESCRIPTION
Disable the Back button in Plan Wizard Results Step

Fixes https://github.com/priley86/miq_v2v_ui_plugin/issues/205

Screenshots show that the `Back` button is disabled in the Results Step -

<img width="806" alt="screen shot 2018-04-13 at 10 41 28 am" src="https://user-images.githubusercontent.com/1538216/38749679-566bf9dc-3f07-11e8-9183-9cca7c5a347a.png">
<img width="811" alt="screen shot 2018-04-13 at 10 41 58 am" src="https://user-images.githubusercontent.com/1538216/38749682-57e844d2-3f07-11e8-9932-27b83ae559dc.png">
