### PR TITLE
Display the amount of time for Migration completion

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationCompletedRow.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationCompletedRow.js
@@ -30,11 +30,11 @@ const MigrationCompletedRow = ({ migration }) => {
 
   let elapsedTime;
   if (days >= 2) {
-    elapsedTime = sprintf(__('%s days %s:%s'), days, hours, minutes);
+    elapsedTime = sprintf(__('%s days %02s:%02s:%02s'), days, hours, minutes, seconds);
   } else if (days === 1) {
-    elapsedTime = sprintf(__('1 day %s:%s'), hours, minutes);
+    elapsedTime = sprintf(__('1 day %02s:%02s:%02s'), hours, minutes, seconds);
   } else {
-    elapsedTime = sprintf(__('%s:%s:%s'), hours, minutes, seconds);
+    elapsedTime = sprintf(__('%02s:%02s:%02s'), hours, minutes, seconds);
   }
 
   const closePopover = () => {

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationCompletedRow.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationCompletedRow.js
@@ -30,7 +30,13 @@ const MigrationCompletedRow = ({ migration }) => {
 
   let elapsedTime;
   if (days >= 2) {
-    elapsedTime = sprintf(__('%s days %02s:%02s:%02s'), days, hours, minutes, seconds);
+    elapsedTime = sprintf(
+      __('%s days %02s:%02s:%02s'),
+      days,
+      hours,
+      minutes,
+      seconds
+    );
   } else if (days === 1) {
     elapsedTime = sprintf(__('1 day %02s:%02s:%02s'), hours, minutes, seconds);
   } else {

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationCompletedRow.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationCompletedRow.js
@@ -20,10 +20,11 @@ const MigrationCompletedRow = ({ migration }) => {
     task => task.status === 'Error'
   ).length;
 
-  const startTime = new Date(migration.options.delivered_on);
-  const endTime = Date.now();
+  const startTime = new Date(migration.created_on);
+  const endTime = new Date(migration.options.delivered_on);
   let hours = moment(endTime).diff(startTime, 'hours');
   const minutes = moment(endTime).diff(startTime, 'minutes') % 60;
+  const seconds = moment(endTime).diff(startTime, 'seconds') % 60;
   const days = Math.floor(hours / 24);
   hours %= 24;
 
@@ -33,7 +34,7 @@ const MigrationCompletedRow = ({ migration }) => {
   } else if (days === 1) {
     elapsedTime = sprintf(__('1 day %s:%s'), hours, minutes);
   } else {
-    elapsedTime = sprintf(__('%s:%s'), hours, minutes);
+    elapsedTime = sprintf(__('%s:%s:%s'), hours, minutes, seconds);
   }
 
   const closePopover = () => {

--- a/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedActions.js
+++ b/app/javascript/react/screens/App/Overview/components/Cards/MigrationsCompletedCard/MigrationsCompletedActions.js
@@ -26,8 +26,9 @@ const fetchMigrationsCompletedAction = () => {
     "filter[]=state='finished'" +
     "&filter[]=type='ServiceTemplateTransformationPlanRequest'" +
     '&expand=resources' +
-    '&attributes=status,state,options,description,miq_request_tasks' +
-    '&sort_by=updated_on';
+    '&attributes=status,state,options,description,miq_request_tasks,created_on' +
+    '&sort_by=updated_on' +
+    '&sort_order=desc';
 
   const uri = new URI(url);
 


### PR DESCRIPTION
Three noticeable changes in the PR -
- Displays the amount of time for Migration completion - calculated as a difference of `delivered_on` and `created_on`
- Sorting was updated to place the most recent plan at the top of the list.
(In the screenshot below, `MyPlanToday` was created today - April 13th)
- ~For time < 1 day, display the time in `h:m:s` format (previously, it did not show seconds)~
Display time in `hh:mm:ss` format consistently (for time < 1 day or otherwise) 

<img width="1076" alt="screen shot 2018-04-13 at 1 56 53 pm" src="https://user-images.githubusercontent.com/1538216/38757671-b4fc2704-3f22-11e8-9cc8-dff321ac33eb.png">

---------
Shows a row with Time in Days HH:MM:SS
<img width="1049" alt="screen shot 2018-04-13 at 2 01 35 pm" src="https://user-images.githubusercontent.com/1538216/38757813-3982d144-3f23-11e8-988c-7b73558e48e3.png">






Fixes https://github.com/priley86/miq_v2v_ui_plugin/issues/194