### PR TITLE
Fixed the Plan API parameters

### DIFF
--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -103,8 +103,8 @@ export const coreComponents = [
         : '/api/service_templates/?' +
           "filter[]=type='ServiceTemplateTransformationPlan'" +
           '&expand=resources' +
-          '&attributes=miq_requests,created_on' +
-          '&sort_by=updated_on' +
+          '&attributes=miq_requests,options,created_at' +
+          '&sort_by=updated_at' +
           '&sort_order=desc',
       fetchClustersUrl: mockMode
         ? '/api/dummyClusters'


### PR DESCRIPTION
@michaelkro Can you review the changes?

Without these changes, I am seeing a 400 error for "Migration Plans not started"

- Reason for 400 - `created_on` and `updated_on` attributes do not exist. Instead, they should be `created_at` and `updated_at`

- Also, we need the `options` attribute