### PR TITLE
Make entire migration in progress card clickable

### DIFF
--- a/app/javascript/react/config/Routes.js
+++ b/app/javascript/react/config/Routes.js
@@ -21,7 +21,15 @@ const Routes = ({ store }) =>
           path={`/${path}`}
           render={props => {
             if (props.match.isExact) {
-              return <React.Fragment>{markup}</React.Fragment>;
+              return (
+                <React.Fragment>
+                  {componentRegistry.markup(
+                    coreComponent.name,
+                    { ...coreComponent.data, ...props },
+                    store
+                  )}
+                </React.Fragment>
+              );
             }
             return markup;
           }}

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -14,7 +14,8 @@ class Overview extends React.Component {
     bindMethods(this, [
       'stopPolling',
       'startPolling',
-      'createTransformationPlanRequest'
+      'createTransformationPlanRequest',
+      'redirectTo'
     ]);
 
     this.mappingWizard = componentRegistry.markup(
@@ -117,6 +118,11 @@ class Overview extends React.Component {
     });
   }
 
+  redirectTo(path) {
+    const { history } = this.props;
+    history.push(path);
+  }
+
   render() {
     const {
       showMappingWizardAction,
@@ -202,6 +208,7 @@ class Overview extends React.Component {
               isCreatingTransformationPlanRequest={
                 isCreatingTransformationPlanRequest
               }
+              redirectTo={this.redirectTo}
             />
           )}
           <InfrastructureMappingsList
@@ -261,6 +268,7 @@ Overview.propTypes = {
   fetchClustersUrl: PropTypes.string,
   clusters: PropTypes.array,
   migrationsFilter: PropTypes.string,
-  setMigrationsFilterAction: PropTypes.func
+  setMigrationsFilterAction: PropTypes.func,
+  history: PropTypes.object
 };
 export default Overview;

--- a/app/javascript/react/screens/App/Overview/Overview.scss
+++ b/app/javascript/react/screens/App/Overview/Overview.scss
@@ -8,6 +8,12 @@ hr {
   margin-top: 10px;
 }
 
+.card-pf {
+  &.in-progress {
+    cursor: pointer;
+  }
+}
+
 .card-pf-body .blank-slate-pf {
   background-color: #fff;
 }

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -15,7 +15,8 @@ const Migrations = ({
   createMigrationPlanClick,
   createTransformationPlanRequestClick,
   isCreatingTransformationPlanRequest,
-  finishedTransformationPlans
+  finishedTransformationPlans,
+  redirectTo
 }) => {
   const filterOptions = [
     'Migration Plans Not Started',
@@ -87,6 +88,7 @@ const Migrations = ({
             <MigrationsInProgressCards
               activeTransformationPlans={activeTransformationPlans}
               loading={isCreatingTransformationPlanRequest !== null}
+              redirectTo={redirectTo}
             />
           )}
           {activeFilter === 'Migration Plans Completed' && (
@@ -111,7 +113,8 @@ Migrations.propTypes = {
   createMigrationPlanClick: PropTypes.func,
   createTransformationPlanRequestClick: PropTypes.func,
   isCreatingTransformationPlanRequest: PropTypes.string,
-  finishedTransformationPlans: PropTypes.array
+  finishedTransformationPlans: PropTypes.array,
+  redirectTo: PropTypes.func
 };
 Migrations.defaultProps = {
   transformationPlans: [],

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import numeral from 'numeral';
-import { Link } from 'react-router-dom';
 import {
   Card,
   EmptyState,
@@ -13,7 +12,7 @@ import {
 } from 'patternfly-react';
 import { IsoElpasedTime } from '../../../../../../components/dates/IsoElapsedTime';
 
-const MigrationsInProgressCard = ({ plan }) => {
+const MigrationsInProgressCard = ({ plan, handleClick }) => {
   const [mostRecentRequest] = plan.miq_requests.slice(-1);
 
   // if most recent request is still pending, show loading card
@@ -92,14 +91,12 @@ const MigrationsInProgressCard = ({ plan }) => {
 
   // Tooltips
   const vmBarLabel = (
-    <Link to={`/migration/plan/${plan.id}`}>
-      <span>
-        <strong className="label-strong">
-          {sprintf(__('%s of %s VMs'), completedVMs, totalVMs)}
-        </strong>{' '}
-        {__('migrated')}
-      </span>
-    </Link>
+    <span>
+      <strong className="label-strong">
+        {sprintf(__('%s of %s VMs'), completedVMs, totalVMs)}
+      </strong>{' '}
+      {__('migrated')}
+    </span>
   );
 
   const diskSpaceBarLabel = (
@@ -152,7 +149,13 @@ const MigrationsInProgressCard = ({ plan }) => {
 
   return (
     <Grid.Col sm={12} md={6} lg={4}>
-      <Card matchHeight>
+      <Card
+        onClick={() => {
+          handleClick(`/migration/plan/${plan.id}`);
+        }}
+        matchHeight
+        className="in-progress"
+      >
         <Card.Heading>
           <OverlayTrigger
             overlay={
@@ -210,7 +213,8 @@ const MigrationsInProgressCard = ({ plan }) => {
 };
 
 MigrationsInProgressCard.propTypes = {
-  plan: PropTypes.object.isRequired
+  plan: PropTypes.object.isRequired,
+  handleClick: PropTypes.func
 };
 
 export default MigrationsInProgressCard;

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCards.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCards.js
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 import { CardGrid, EmptyState, Spinner } from 'patternfly-react';
 import MigrationInProgressCard from './MigrationsInProgressCard';
 
-const MigrationsInProgressCards = ({ activeTransformationPlans, loading }) => (
+const MigrationsInProgressCards = ({
+  activeTransformationPlans,
+  loading,
+  redirectTo
+}) => (
   <CardGrid
     matchHeight
     style={{
@@ -16,7 +20,11 @@ const MigrationsInProgressCards = ({ activeTransformationPlans, loading }) => (
       <Spinner loading={loading}>
         {activeTransformationPlans.length > 0 &&
           activeTransformationPlans.map(plan => (
-            <MigrationInProgressCard plan={plan} key={plan.id} />
+            <MigrationInProgressCard
+              plan={plan}
+              key={plan.id}
+              handleClick={redirectTo}
+            />
           ))}
         {activeTransformationPlans.length === 0 && (
           <EmptyState>
@@ -34,7 +42,8 @@ const MigrationsInProgressCards = ({ activeTransformationPlans, loading }) => (
 
 MigrationsInProgressCards.propTypes = {
   activeTransformationPlans: PropTypes.array,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  redirectTo: PropTypes.func
 };
 
 MigrationsInProgressCards.defaultProps = {


### PR DESCRIPTION
* Pass route props from react-router to Route components
* Create redirectTo method in Overview
* Closes https://github.com/priley86/miq_v2v_ui_plugin/issues/217

## Notes
1. Normally the `react-router` route props are spread out into the component being rendered in `<Route>`, but in this case, due to `componentRegistry`, had to find a way to pass the data down.
2. Adds styles to make mouse cursor a `pointer` for in progress cards
3. `VMs Migrated` text is no longer a link

## Screens
![click](https://user-images.githubusercontent.com/15141412/38895403-fb095b34-425d-11e8-8786-abc22cb6c748.gif)
