### PR TITLE
Reset pagination when adding a filter

### DIFF
--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList.js
@@ -225,11 +225,17 @@ class PlanRequestDetailList extends React.Component {
     filterText += ': ';
     filterText += value.title || value;
 
-    const activeFilters = [
-      ...this.state.activeFilters,
-      { label: filterText, field, value: value.title || value }
-    ];
-    this.setState({ activeFilters });
+    this.setState(prevState => ({
+      activeFilters: [
+        ...prevState.activeFilters,
+        { label: filterText, field, value: value.title || value }
+      ],
+      pagination: {
+        ...prevState.pagination,
+        page: 1
+      },
+      pageChangeValue: 1
+    }));
   };
   totalPages = () => {
     const { activeFilters, pagination } = this.state;


### PR DESCRIPTION
Filtering the plan tasks returns a new list and thus pagination should
be reset

Closes https://github.com/priley86/miq_v2v_ui_plugin/issues/215