### PR TITLE
Fix url for creating plan request

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -31,6 +31,8 @@ const MigrationsCompletedList = ({
           new Date(mostRecentRequest.options.delivered_on)
         );
 
+        const url = `/api/service_templates/${plan.id}`;
+
         return (
           <ListView.Item
             key={plan.id}
@@ -64,9 +66,9 @@ const MigrationsCompletedList = ({
               (failed && (
                 <Button
                   onClick={() => {
-                    retryClick(plan.href);
+                    retryClick(url);
                   }}
-                  disabled={loading === plan.href}
+                  disabled={loading === url}
                 >
                   Retry
                 </Button>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -9,33 +9,36 @@ const MigrationsNotStartedList = ({
 }) => (
   <Grid.Col xs={12}>
     <ListView style={{ marginTop: 0 }}>
-      {notStartedPlans.map(plan => (
-        <ListView.Item
-          actions={
-            <div>
-              <Button
-                onClick={() => {
-                  migrateClick(plan.href);
-                }}
-                disabled={loading === plan.href}
-              >
-                Migrate
-              </Button>
-            </div>
-          }
-          leftContent={<div />}
-          heading={plan.name}
-          description={plan.description}
-          additionalInfo={[
-            <ListView.InfoItem key={plan.id}>
-              <Icon type="pf" name="virtual-machine" />
-              <strong>{plan.options.config_info.vm_ids.length}</strong>{' '}
-              {__('VMs')}
-            </ListView.InfoItem>
-          ]}
-          key={plan.id}
-        />
-      ))}
+      {notStartedPlans.map(plan => {
+        const url = `/api/service_templates/${plan.id}`;
+        return (
+          <ListView.Item
+            actions={
+              <div>
+                <Button
+                  onClick={() => {
+                    migrateClick(url);
+                  }}
+                  disabled={loading === url}
+                >
+                  Migrate
+                </Button>
+              </div>
+            }
+            leftContent={<div />}
+            heading={plan.name}
+            description={plan.description}
+            additionalInfo={[
+              <ListView.InfoItem key={plan.id}>
+                <Icon type="pf" name="virtual-machine" />
+                <strong>{plan.options.config_info.vm_ids.length}</strong>{' '}
+                {__('VMs')}
+              </ListView.InfoItem>
+            ]}
+            key={plan.id}
+          />
+        );
+      })}
     </ListView>
   </Grid.Col>
 );


### PR DESCRIPTION
Previous implementation was causing an error. We only want the
domain name here.

## Notes
1. You'll see this error when clicking on either the `Retry` or `Migrate` buttons in the Migration Plans Completed or Migration Plans Not Started sections, respectively
    ```
    Refused to connect to 'http://localhost:3000/api/service_templates/10' because it violates the 
    following Content Security Policy directive: "connect-src 'self' ws://localhost:8080".
    ```

2. With this change, you'll see `CREATE_V2V_TRANSFORMATION_PLAN_REQUEST` fulfill with no errors (in `mockMode`)