### PR TITLE
Fix browser tab title and icon

### DIFF
--- a/app/views/layouts/migration.html.haml
+++ b/app/views/layouts/migration.html.haml
@@ -1,8 +1,9 @@
 !!!
 %html.layout-pf.layout-pf-fixed.transitions{:lang => I18n.locale.to_s.sub('-', '_')}
-  %body
-    %p
-    %title ManageIQ v2v plugin
+  %head
+    %title
+      = "%{product}: %{title}" % {:product => Vmdb::Appliance.PRODUCT_NAME, :title => _("Migration")}
+    = favicon_link_tag
     = stylesheet_link_tag "application", media: "all"
     = stylesheet_link_tag "miq_v2v_ui/application", media: "all"
     = javascript_pack_tag 'vendor'
@@ -14,4 +15,3 @@
     = render :partial => "layouts/vertical_navbar"
     .container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus{:style => "overflow: hidden; height: 100%"}
       = yield
-


### PR DESCRIPTION
Fixed browser tab title and icon

Before:
<img width="585" alt="screen shot 2018-04-19 at 2 46 01 pm" src="https://user-images.githubusercontent.com/1538216/39020154-af83e934-43e0-11e8-9d5b-acead4ae643c.png">

-----------------------------

After:
<img width="577" alt="screen shot 2018-04-19 at 2 45 12 pm" src="https://user-images.githubusercontent.com/1538216/39020143-a2c020dc-43e0-11e8-969a-47e3263536c4.png">


Fixes #234
