### PR TITLE
Set Migrations filter

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js
@@ -36,18 +36,32 @@ class PlanWizard extends React.Component {
       planWizardVMStep,
       planWizardOptionsStep,
       setPlansBodyAction,
-      setPlanScheduleAction
+      setPlanScheduleAction,
+      setMigrationsFilterAction
     } = this.props;
+
     if (activeStepIndex === 2) {
       const plansBody = createMigrationPlans(
         planWizardGeneralStep,
         planWizardVMStep
       );
+
       setPlanScheduleAction(
         planWizardOptionsStep.values.migration_plan_choice_radio
       );
-
       setPlansBodyAction(plansBody);
+
+      if (
+        planWizardOptionsStep.values.migration_plan_choice_radio ===
+        'migration_plan_now'
+      ) {
+        setMigrationsFilterAction('Migration Plans in Progress');
+      } else if (
+        planWizardOptionsStep.values.migration_plan_choice_radio ===
+        'migration_plan_later'
+      ) {
+        setMigrationsFilterAction('Migration Plans Not Started');
+      }
     }
 
     this.setState({
@@ -151,7 +165,8 @@ PlanWizard.propTypes = {
   planWizardOptionsStep: PropTypes.object,
   setPlansBodyAction: PropTypes.func,
   setPlanScheduleAction: PropTypes.func,
-  resetVmStepAction: PropTypes.func
+  resetVmStepAction: PropTypes.func,
+  setMigrationsFilterAction: PropTypes.func
 };
 PlanWizard.defaultProps = {
   hidePlanWizard: true,

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/__tests__/__snapshots__/index.test.js.snap
@@ -9,6 +9,7 @@ Object {
   "planWizardOptionsStep": Object {},
   "planWizardVMStep": Object {},
   "resetVmStepAction": [Function],
+  "setMigrationsFilterAction": [Function],
   "setPlanScheduleAction": [Function],
   "setPlansBodyAction": [Function],
 }

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/index.js
@@ -5,6 +5,7 @@ import {
   planWizardOverviewFilter,
   planWizardFormFilter
 } from './PlanWizardSelectors';
+import { setMigrationsFilterAction } from '../../OverviewActions';
 
 import reducer from './PlanWizardReducer';
 
@@ -20,9 +21,12 @@ const mapStateToProps = ({ overview, planWizard, form }, ownProps) => {
   };
 };
 
+const actions = {
+  ...PlanWizardActions,
+  setMigrationsFilterAction
+};
+
 const mergeProps = (stateProps, dispatchProps, ownProps) =>
   Object.assign(stateProps, ownProps.data, dispatchProps);
 
-export default connect(mapStateToProps, PlanWizardActions, mergeProps)(
-  PlanWizard
-);
+export default connect(mapStateToProps, actions, mergeProps)(PlanWizard);


### PR DESCRIPTION
* If the user chooses to start migration immediately, set filter so that
  they see the Migrations in Progress section upon closing wizard
* If the user chooses to start migration later, set filter so that they
  see the Migrations not Started section upon closing wizard