### PR TITLE
Fix for elapsed time and spinner for completed migrations

### DIFF
--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -35,7 +35,9 @@ const _formatPlanRequestDetails = data => {
           task.options && task.options.transformation_host_name,
         delivered_on: new Date(task.options.delivered_on),
         updated_on: new Date(task.updated_on),
-        completed: task.message === 'VM Transformations completed',
+        completed:
+          task.message === 'VM Transformations completed' ||
+          task.message === 'VM Transformations failed',
         state: task.state,
         status: task.status,
         options: {}
@@ -43,11 +45,6 @@ const _formatPlanRequestDetails = data => {
 
       taskDetails.options.progress = task.options.progress;
       taskDetails.options.virtv2v_wrapper = task.options.virtv2v_wrapper;
-
-      taskDetails.taskCompleted = task.completed;
-      if (task.status === 'Error') {
-        taskDetails.taskCompleted = true;
-      }
 
       if (!task.diskSpaceCompletedGb) {
         taskDetails.diskSpaceCompletedGb = '0';
@@ -70,7 +67,9 @@ const _formatPlanRequestDetails = data => {
       if (taskDetails.completed) {
         taskDetails.completedSuccessfully =
           task.options.progress.current_description ===
-          'Virtual machine migrated';
+            'Virtual machine migrated' ||
+          task.options.progress.current_description ===
+            'Mark source as migrated';
       }
       if (
         task.options &&

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -350,7 +350,7 @@ class PlanRequestDetailList extends React.Component {
                     style={{ width: 'inherit', backgroundColor: 'transparent' }}
                   />
                 );
-              } else if (task.taskCompleted && !task.completedSuccessfully) {
+              } else if (task.completed && !task.completedSuccessfully) {
                 leftContent = (
                   <ListView.Icon
                     type="pf"
@@ -359,7 +359,7 @@ class PlanRequestDetailList extends React.Component {
                     style={{ width: 'inherit', backgroundColor: 'transparent' }}
                   />
                 );
-              } else if (task.taskCompleted) {
+              } else if (task.completed) {
                 leftContent = (
                   <ListView.Icon
                     type="pf"
@@ -376,7 +376,7 @@ class PlanRequestDetailList extends React.Component {
               const lastUpdateDateTime = task.updated_on;
               const elapsedTime = IsoElpasedTime(
                 startDateTime,
-                task.taskCompleted ? lastUpdateDateTime : currentTime
+                task.completed ? lastUpdateDateTime : currentTime
               );
               const label = sprintf(
                 __('%s of %s Migrated'),


### PR DESCRIPTION
`task.completed` will be driven by `task.message` values, and with that we do not need `taskDetails.taskCompleted` anymore.

Completed Successful VM Migrations - Before (in mock mode) - 
<img width="1307" alt="screen shot 2018-05-01 at 1 17 39 pm" src="https://user-images.githubusercontent.com/1538216/39491958-d164b748-4d42-11e8-847e-80fd290183b5.png">

Completed Successful VM Migrations - After (in mock mode) - 
<img width="1308" alt="screen shot 2018-05-01 at 1 18 53 pm" src="https://user-images.githubusercontent.com/1538216/39491975-e299ce86-4d42-11e8-9b62-2c0836f5e595.png">




Fixes https://github.com/priley86/miq_v2v_ui_plugin/issues/272 and https://github.com/priley86/miq_v2v_ui_plugin/issues/273