### PR TITLE
`migrated` and `in_other_plan` VMs can be selectable

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
@@ -28,9 +28,17 @@ const _formatValidVms = vms =>
 const _formatInvalidVms = vms =>
   vms &&
   vms.map(v => {
-    v.invalid = true;
     v.allocated_size = numeral(v.allocated_size).format('0.00b');
     v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
+    if (
+      v.reason === V2V_VM_POST_VALIDATION_REASONS.migrated ||
+      v.reason === V2V_VM_POST_VALIDATION_REASONS.in_other_plan
+    ) {
+      v.warning = true;
+    } else {
+      v.invalid = true;
+    }
+
     return v;
   });
 const _formatConflictVms = vms =>

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/PlanWizardVMStepTable.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/PlanWizardVMStepTable.js
@@ -183,7 +183,13 @@ class PlanWizardVMStepTable extends React.Component {
                     <Button bsStyle="link">
                       <Icon
                         type="pf"
-                        name={rowData.valid ? 'ok' : 'error-circle-o'}
+                        name={
+                          rowData.valid
+                            ? 'ok'
+                            : rowData.warning
+                              ? 'warning-triangle-o'
+                              : 'error-circle-o'
+                        }
                       />
                     </Button>
                   </OverlayTrigger>


### PR DESCRIPTION
Change the status of `migrated` and `in_other_plan` VMs from errors to warnings and make them selectable.

<img width="724" alt="screen shot 2018-05-01 at 2 34 54 pm" src="https://user-images.githubusercontent.com/1538216/39495054-84e9777c-4d4d-11e8-91a9-b35ddc53c76d.png">

Fixes https://github.com/priley86/miq_v2v_ui_plugin/issues/274

