### PR TITLE
Update transformation plan fixtures

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/__test__/ActiveTransformationPlans.test.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/__test__/ActiveTransformationPlans.test.js
@@ -4,14 +4,18 @@ import { shallow } from 'enzyme';
 import ActiveTransformationPlans from '../ActiveTransformationPlans';
 import { activeTransformationPlansFilter } from '../../../../OverviewSelectors';
 import { transformationPlans } from '../../../../overview.transformationPlans.fixtures';
+import { allRequestsWithTasks } from '../../../../overview.requestWithTasks.fixtures';
 
 const { resources: plans } = transformationPlans;
+const { results: requests } = allRequestsWithTasks;
 const activePlans = activeTransformationPlansFilter(plans);
 
 test('displays the number of active transformation plans with an error', () => {
-  const [, activePlan, erroredPlan] = activePlans;
   const wrapper = shallow(
-    <ActiveTransformationPlans activePlans={[activePlan, erroredPlan]} />
+    <ActiveTransformationPlans
+      activePlans={activePlans}
+      allRequestsWithTasks={requests}
+    />
   );
 
   expect(wrapper.find('Icon').prop('name')).toBe('error-circle-o');
@@ -20,5 +24,5 @@ test('displays the number of active transformation plans with an error', () => {
       .find('AggregateStatusNotification')
       .childAt(2)
       .text()
-  ).toBe('2');
+  ).toBe('1');
 });

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -10,7 +10,7 @@ const MigrationsNotStartedList = ({
   redirectTo
 }) => (
   <Grid.Col xs={12}>
-    <Spinner loading={loading}>
+    <Spinner loading={!!loading}>
       {notStartedPlans.length > 0 ? (
         <ListView className="plans-not-started-list" style={{ marginTop: 0 }}>
           {notStartedPlans.map(plan => (
@@ -71,7 +71,7 @@ const MigrationsNotStartedList = ({
 MigrationsNotStartedList.propTypes = {
   migrateClick: PropTypes.func,
   notStartedPlans: PropTypes.array,
-  loading: PropTypes.bool,
+  loading: PropTypes.string,
   redirectTo: PropTypes.func
 };
 MigrationsNotStartedList.defaultProps = {

--- a/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
+++ b/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
@@ -10,30 +10,22 @@ export const transformationPlans = Immutable({
     // PLAN A-0 QUEUED / NOT STARTED
     {
       href: 'http://localhost:3000/api/service_templates/10',
-      id: '10',
       name: 'Migration Plan A-0',
-      description: 'Migration Plan description here',
-      guid: '7de52447-2946-409d-8e76-b64d0f17803d',
-      type: 'ServiceTemplateTransformationPlan',
-      service_template_id: null,
       options: {
         config_info: {
           transformation_mapping_id: '1',
           vm_ids: ['1', '3']
         }
       },
+      created_at: '2018-05-01T12:15:00Z',
+      id: '10',
       miq_requests: []
     },
     // PLAN B-0 APPROVED
     // |-- Request 1: pending
     {
       href: 'http://localhost:3000/api/service_templates/20',
-      id: '20',
       name: 'Migration Plan B-0',
-      description: '',
-      guid: '1f49ea91-8503-4d0c-a3b3-c6958bd95a5d',
-      type: 'ServiceTemplateTransformationPlan',
-      service_template_id: null,
       options: {
         config_info: {
           transformation_mapping_id: '1',
@@ -45,2084 +37,274 @@ export const transformationPlans = Immutable({
           href: 'http://localhost:3000/api/service_requests/2000',
           id: '2000',
           description: 'Migration Plan B-0',
-          state: '',
-          approval_state: 'approved',
-          request_state: 'pending',
-          status: 'Ok',
+          approval_state: 'pending_approval',
+          type: 'ServiceTemplateTransformationPlanRequest',
           created_on: '2018-04-06T12:31:30Z',
+          updated_on: '2018-04-06T12:31:30Z',
+          fulfilled_on: null,
+          requester_id: '1',
+          requester_name: 'Administrator',
+          request_type: 'transformation_plan',
+          request_state: 'pending',
+          message: 'VM Transformations - Request Created',
+          status: 'Ok',
           options: {
+            dialog: null,
+            workflow_settings: {
+              resource_action_id: '4508'
+            },
+            initiator: null,
             src_id: '6',
             cart_state: 'ordered',
-            delivered_on: '2018-04-06T12:32:30Z', // can use this timestamp as the starting time for this request
-            user_message: '[EVM] VM Migrated Successfully'
+            requester_group: 'EvmGroup-super_administrator'
           },
-          miq_request_tasks: []
+          userid: 'admin',
+          source_id: '20',
+          source_type: 'ServiceTemplate',
+          destination_id: null,
+          destination_type: null,
+          tenant_id: '1',
+          service_order_id: '92',
+          process: true
         }
       ]
     },
     // PLAN C-0 APPROVED
     // |-- Request 1: failed
-    // |---- Task 1: failed
-    // |---- Task 2: failed
     // |-- Request 2: active
-    // |---- Task 1: active
-    // |---- Task 2: finished
     {
       href: 'http://localhost:3000/api/service_templates/30',
-      id: '30',
       name: 'Migration Plan C-0',
-      description: '',
-      guid: '29bd9165-72bb-4b99-9d90-c383913ef0b3',
-      type: 'ServiceTemplateTransformationPlan',
-      service_template_id: null,
       options: {
         config_info: {
           transformation_mapping_id: '1',
           vm_ids: ['1', '3']
         }
       },
+      created_at: '2018-05-01T12:13:50Z',
+      id: '30',
       miq_requests: [
         {
           href: 'http://localhost:3000/api/service_requests/3000',
           id: '3000',
           description: 'Migration Plan C-0',
-          state: '',
           approval_state: 'approved',
-          request_state: 'failed',
-          status: 'Error',
+          type: 'ServiceTemplateTransformationPlanRequest',
           created_on: '2018-04-06T12:31:30Z',
+          updated_on: '2018-04-06T12:31:30Z',
+          fulfilled_on: '2018-04-06T12:31:30Z',
+          requester_id: '1',
+          requester_name: 'Administrator',
+          request_type: 'transformation_plan',
+          request_state: 'finished',
+          message: 'VM Transformations failed',
+          status: 'Error',
           options: {
-            src_id: '6',
-            cart_state: 'ordered',
-            delivered_on: '2018-04-06T12:49:30Z', // can use this timestamp as the starting time for this request
-            user_message: '[EVM] VM Migrated Successfully'
-          },
-          miq_request_tasks: [
-            {
-              created_on: '2018-04-06T12:31:30Z',
-              description: 'Transforming VM [test_migration]',
-              destination_id: null,
-              destination_type: null,
-              href: 'http://localhost:3000/api/request_tasks/300',
-              id: '300',
-              message: 'VM Transformations completed',
-              miq_request_id: '300',
-              miq_request_task_id: null,
-              options: {
-                cart_state: 'ordered',
-                collapse_snapshots: true,
-                delivered_on: '2018-04-06T12:31:30.871Z',
-                destination_vm_id: '48',
-                dialog: null,
-                export_domain_id: '1',
-                initiator: null,
-                power_off: true,
-                progress: {
-                  current_description: '<SOMETHING>',
-                  current_state: '/State7',
-                  percent: 100.0,
-                  states: {
-                    '/State1': {
-                      description: 'Assess Migration',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:31:52Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:32:28Z',
-                      weight: 1
-                    },
-                    '/State2': {
-                      description: 'Acquire Transformation Host',
-                      message: 'State2 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:32:44Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:33:20Z',
-                      weight: 1
-                    },
-                    '/State3': {
-                      description: 'Power off',
-                      message: 'State3 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:33:35Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:06Z',
-                      weight: 1
-                    },
-                    '/State4': {
-                      description: 'Collapse Snapshots',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:34:22Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:53Z',
-                      weight: 1
-                    },
-                    '/State5': {
-                      description: 'Transform VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:09Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:28Z',
-                      weight: 95
-                    },
-                    '/State5/State1': {
-                      description: 'Convert disks',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:24Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:36:16Z',
-                      weight: 1
-                    },
-                    '/State5/State2': {
-                      description: 'Convert disks',
-                      message: 'Disks transformation succeeded.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:36:32Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:40:33Z',
-                      weight: 85
-                    },
-                    '/State5/State4': {
-                      description: 'Identify destination VM',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:40:48Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:07Z',
-                      weight: 4
-                    },
-                    '/State5/State5': {
-                      description: 'Update description of VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:43:23Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:59Z',
-                      weight: 1
-                    },
-                    '/State5/State6': {
-                      description: 'Enable Virtio-SCSI for VM',
-                      message: 'State6 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:44:15Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:44:52Z',
-                      weight: 1
-                    },
-                    '/State5/State8': {
-                      description: 'Power-on VM',
-                      message: 'State8 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:07Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:45:38Z',
-                      weight: 1
-                    },
-                    '/State5/State9': {
-                      description: 'Power-on VM',
-                      message: 'State9 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:54Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:12Z',
-                      weight: 7
-                    },
-                    '/State6': {
-                      description: 'Mark source as migrated',
-                      message: 'exit',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:48:43Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:49:14Z',
-                      weight: 1
-                    },
-                    '/State7': {
-                      description: 'Virtual machine migrated',
-                      message: 'Virtual machine migrated',
-                      percent: 0.0,
-                      started_on: '2018-04-06T12:49:30Z',
-                      status: 'active',
-                      weight: 1
-                    }
-                  }
-                },
-                requester_group: 'EvmGroup-super_administrator',
-                src_id: '3',
-                transformation_host_id: '1',
-                transformation_host_name: 'rhvh01.example.com',
-                virtv2v_disks: [
-                  {
-                    path: '[NFS_Datastore] test_migration/test_migration.vmdk',
-                    percent: 50,
-                    size: 8589934592,
-                    weight: 50
-                  }
-                ],
-                virtv2v_finished_on: '20180406_0840',
-                virtv2v_networks: [
-                  {
-                    destination: 'VM_Network',
-                    source: 'VM Network'
-                  }
-                ],
-                virtv2v_started_on: '2018-04-06 08:35:45',
-                virtv2v_status: 'active',
-                virtv2v_wrapper: {
-                  state_file: '/tmp/v2v-import-20180406T083602-116599.state',
-                  v2v_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599.log',
-                  wrapper_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599-wrapper.log'
-                },
-                workflow_settings: {
-                  resource_action_id: '22'
-                }
-              },
-              phase: null,
-              phase_context: {},
-              request_state: 'Finished',
-              request_type: 'transformation_plan',
-              source_id: '26',
-              source_type: 'VmOrTemplate',
-              state: 'finished',
-              status: 'Error',
-              tenant_id: '1',
-              type: 'ServiceTemplateTransformationPlanTask',
-              updated_on: '2018-04-06T12:49:30Z',
-              userid: 'admin'
+            dialog: null,
+            workflow_settings: {
+              resource_action_id: '4351'
             },
-            {
-              created_on: '2018-04-06T12:31:30Z',
-              description: 'Transforming VM [test_migration]',
-              destination_id: null,
-              destination_type: null,
-              href: 'http://localhost:3000/api/request_tasks/300',
-              id: '301',
-              message: 'Migrating',
-              miq_request_id: '300',
-              miq_request_task_id: null,
-              options: {
-                cart_state: 'ordered',
-                collapse_snapshots: true,
-                delivered_on: '2018-04-06T12:31:30.871Z',
-                destination_vm_id: '48',
-                dialog: null,
-                export_domain_id: '1',
-                initiator: null,
-                power_off: true,
-                progress: {
-                  current_description: '<SOMETHING>',
-                  current_state: '/State7',
-                  percent: 50.0,
-                  states: {
-                    '/State1': {
-                      description: 'Assess Migration',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:31:52Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:32:28Z',
-                      weight: 1
-                    },
-                    '/State2': {
-                      description: 'Acquire Transformation Host',
-                      message: 'State2 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:32:44Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:33:20Z',
-                      weight: 1
-                    },
-                    '/State3': {
-                      description: 'Power off',
-                      message: 'State3 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:33:35Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:06Z',
-                      weight: 1
-                    },
-                    '/State4': {
-                      description: 'Collapse Snapshots',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:34:22Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:53Z',
-                      weight: 1
-                    },
-                    '/State5': {
-                      description: 'Transform VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:09Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:28Z',
-                      weight: 95
-                    },
-                    '/State5/State1': {
-                      description: 'Convert disks',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:24Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:36:16Z',
-                      weight: 1
-                    }
-                  }
-                },
-                requester_group: 'EvmGroup-super_administrator',
-                src_id: '5',
-                transformation_host_id: '1',
-                transformation_host_name: 'rhvh01.example.com',
-                virtv2v_disks: [
-                  {
-                    path: '[NFS_Datastore] test_migration/test_migration.vmdk',
-                    percent: 50,
-                    size: 17179869184,
-                    weight: 50
-                  }
-                ],
-                virtv2v_finished_on: '20180406_0840',
-                virtv2v_networks: [
-                  {
-                    destination: 'VM_Network',
-                    source: 'VM Network'
-                  }
-                ],
-                virtv2v_started_on: '2018-04-06 08:35:45',
-                virtv2v_status: 'active',
-                virtv2v_wrapper: {
-                  state_file: '/tmp/v2v-import-20180406T083602-116599.state',
-                  v2v_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599.log',
-                  wrapper_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599-wrapper.log'
-                },
-                workflow_settings: {
-                  resource_action_id: '22'
-                }
-              },
-              phase: null,
-              phase_context: {},
-              request_state: 'Finished',
-              request_type: 'transformation_plan',
-              source_id: '27',
-              source_type: 'VmOrTemplate',
-              state: 'finished',
-              status: 'Error',
-              tenant_id: '1',
-              type: 'ServiceTemplateTransformationPlanTask',
-              updated_on: '2018-04-06T12:49:30Z',
-              userid: 'admin'
-            }
-          ]
+            initiator: null,
+            src_id: '30',
+            cart_state: 'ordered',
+            requester_group: 'EvmGroup-super_administrator',
+            delivered_on: '2018-04-06T12:49:30Z'
+          },
+          userid: 'admin',
+          source_id: '30',
+          source_type: 'ServiceTemplate',
+          destination_id: null,
+          destination_type: null,
+          tenant_id: '1',
+          service_order_id: '91',
+          process: true
         },
         {
           href: 'http://localhost:3000/api/service_requests/3001',
           id: '3001',
           description: 'Migration Plan C-0',
-          state: '',
           approval_state: 'approved',
-          request_state: 'active',
-          status: 'Ok',
+          type: 'ServiceTemplateTransformationPlanRequest',
           created_on: '2018-04-06T12:31:30Z',
+          updated_on: '2018-04-06T12:31:30Z',
+          fulfilled_on: '2018-04-06T12:31:30Z',
+          requester_id: '1',
+          requester_name: 'Administrator',
+          request_type: 'transformation_plan',
+          request_state: 'active',
+          message: '<SOMETHING>',
+          status: 'Ok',
           options: {
-            src_id: '6',
-            cart_state: 'ordered',
-            delivered_on: '2018-04-06T12:49:30Z', // can use this timestamp as the starting time for this request
-            user_message: '[EVM] VM Migrated Successfully'
-          },
-          miq_request_tasks: [
-            {
-              created_on: '2018-04-06T12:31:30Z',
-              description: 'Transforming VM [test_migration]',
-              destination_id: null,
-              destination_type: null,
-              href: 'http://localhost:3000/api/request_tasks/301',
-              id: '301',
-              message: 'Migrating',
-              miq_request_id: '301',
-              miq_request_task_id: null,
-              options: {
-                cart_state: 'ordered',
-                collapse_snapshots: true,
-                delivered_on: '2018-04-06T12:31:30.871Z',
-                destination_vm_id: '48',
-                dialog: null,
-                export_domain_id: '1',
-                initiator: null,
-                power_off: true,
-                progress: {
-                  current_description: '<SOMETHING>',
-                  current_state: '/State7',
-                  percent: 100.0,
-                  states: {
-                    '/State1': {
-                      description: 'Assess Migration',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:31:52Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:32:28Z',
-                      weight: 1
-                    },
-                    '/State2': {
-                      description: 'Acquire Transformation Host',
-                      message: 'State2 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:32:44Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:33:20Z',
-                      weight: 1
-                    },
-                    '/State3': {
-                      description: 'Power off',
-                      message: 'State3 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:33:35Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:06Z',
-                      weight: 1
-                    },
-                    '/State4': {
-                      description: 'Collapse Snapshots',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:34:22Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:53Z',
-                      weight: 1
-                    },
-                    '/State5': {
-                      description: 'Transform VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:09Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:28Z',
-                      weight: 95
-                    },
-                    '/State5/State1': {
-                      description: 'Convert disks',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:24Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:36:16Z',
-                      weight: 1
-                    },
-                    '/State5/State2': {
-                      description: 'Convert disks',
-                      message: 'Disks transformation succeeded.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:36:32Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:40:33Z',
-                      weight: 85
-                    },
-                    '/State5/State4': {
-                      description: 'Identify destination VM',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:40:48Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:07Z',
-                      weight: 4
-                    },
-                    '/State5/State5': {
-                      description: 'Update description of VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:43:23Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:59Z',
-                      weight: 1
-                    },
-                    '/State5/State6': {
-                      description: 'Enable Virtio-SCSI for VM',
-                      message: 'State6 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:44:15Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:44:52Z',
-                      weight: 1
-                    },
-                    '/State5/State8': {
-                      description: 'Power-on VM',
-                      message: 'State8 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:07Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:45:38Z',
-                      weight: 1
-                    },
-                    '/State5/State9': {
-                      description: 'Power-on VM',
-                      message: 'State9 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:54Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:12Z',
-                      weight: 7
-                    },
-                    '/State6': {
-                      description: 'Mark source as migrated',
-                      message: 'exit',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:48:43Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:49:14Z',
-                      weight: 1
-                    },
-                    '/State7': {
-                      description: 'Virtual machine migrated',
-                      message: 'Virtual machine migrated',
-                      percent: 0.0,
-                      started_on: '2018-04-06T12:49:30Z',
-                      status: 'active',
-                      weight: 1
-                    }
-                  }
-                },
-                requester_group: 'EvmGroup-super_administrator',
-                src_id: '2',
-                transformation_host_id: '1',
-                transformation_host_name: 'rhvh01.example.com',
-                virtv2v_disks: [
-                  {
-                    path: '[NFS_Datastore] test_migration/test_migration.vmdk',
-                    percent: 70,
-                    size: 17179869184,
-                    weight: 70
-                  }
-                ],
-                virtv2v_finished_on: '20180406_0840',
-                virtv2v_networks: [
-                  {
-                    destination: 'VM_Network',
-                    source: 'VM Network'
-                  }
-                ],
-                virtv2v_started_on: '2018-04-06 08:35:45',
-                virtv2v_status: 'active',
-                virtv2v_wrapper: {
-                  state_file: '/tmp/v2v-import-20180406T083602-116599.state',
-                  v2v_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599.log',
-                  wrapper_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599-wrapper.log'
-                },
-                workflow_settings: {
-                  resource_action_id: '22'
-                }
-              },
-              phase: null,
-              phase_context: {},
-              request_state: '<SOMETHING>',
-              request_type: 'transformation_plan',
-              source_id: '26',
-              source_type: 'VmOrTemplate',
-              state: 'active',
-              status: 'Ok',
-              tenant_id: '1',
-              type: 'ServiceTemplateTransformationPlanTask',
-              updated_on: '2018-04-06T12:49:30Z',
-              userid: 'admin'
+            dialog: null,
+            workflow_settings: {
+              resource_action_id: '4351'
             },
-            {
-              created_on: '2018-04-06T12:31:30Z',
-              description: 'Transforming VM [test_migration]',
-              destination_id: null,
-              destination_type: null,
-              href: 'http://localhost:3000/api/request_tasks/301',
-              id: '301',
-              message: 'Migrating',
-              miq_request_id: '301',
-              miq_request_task_id: null,
-              options: {
-                cart_state: 'ordered',
-                collapse_snapshots: true,
-                delivered_on: '2018-04-06T12:31:30.871Z',
-                destination_vm_id: '48',
-                dialog: null,
-                export_domain_id: '1',
-                initiator: null,
-                power_off: true,
-                progress: {
-                  current_description: '<SOMETHING>',
-                  current_state: '/State7',
-                  percent: 100.0,
-                  states: {
-                    '/State1': {
-                      description: 'Assess Migration',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:31:52Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:32:28Z',
-                      weight: 1
-                    },
-                    '/State2': {
-                      description: 'Acquire Transformation Host',
-                      message: 'State2 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:32:44Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:33:20Z',
-                      weight: 1
-                    },
-                    '/State3': {
-                      description: 'Power off',
-                      message: 'State3 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:33:35Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:06Z',
-                      weight: 1
-                    },
-                    '/State4': {
-                      description: 'Collapse Snapshots',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:34:22Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:53Z',
-                      weight: 1
-                    },
-                    '/State5': {
-                      description: 'Transform VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:09Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:28Z',
-                      weight: 95
-                    },
-                    '/State5/State1': {
-                      description: 'Convert disks',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:24Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:36:16Z',
-                      weight: 1
-                    },
-                    '/State5/State2': {
-                      description: 'Convert disks',
-                      message: 'Disks transformation succeeded.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:36:32Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:40:33Z',
-                      weight: 85
-                    },
-                    '/State5/State4': {
-                      description: 'Identify destination VM',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:40:48Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:07Z',
-                      weight: 4
-                    },
-                    '/State5/State5': {
-                      description: 'Update description of VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:43:23Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:59Z',
-                      weight: 1
-                    },
-                    '/State5/State6': {
-                      description: 'Enable Virtio-SCSI for VM',
-                      message: 'State6 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:44:15Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:44:52Z',
-                      weight: 1
-                    },
-                    '/State5/State8': {
-                      description: 'Power-on VM',
-                      message: 'State8 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:07Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:45:38Z',
-                      weight: 1
-                    },
-                    '/State5/State9': {
-                      description: 'Power-on VM',
-                      message: 'State9 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:54Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:12Z',
-                      weight: 7
-                    },
-                    '/State6': {
-                      description: 'Mark source as migrated',
-                      message: 'exit',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:48:43Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:49:14Z',
-                      weight: 1
-                    },
-                    '/State7': {
-                      description: 'Virtual machine migrated',
-                      message: 'Virtual machine migrated',
-                      percent: 0.0,
-                      started_on: '2018-04-06T12:49:30Z',
-                      status: 'active',
-                      weight: 1
-                    }
-                  }
-                },
-                requester_group: 'EvmGroup-super_administrator',
-                src_id: '2',
-                transformation_host_id: '1',
-                transformation_host_name: 'rhvh01.example.com',
-                virtv2v_disks: [
-                  {
-                    path: '[NFS_Datastore] test_migration/test_migration.vmdk',
-                    percent: 100,
-                    size: 17179869184,
-                    weight: 100
-                  }
-                ],
-                virtv2v_finished_on: '20180406_0840',
-                virtv2v_networks: [
-                  {
-                    destination: 'VM_Network',
-                    source: 'VM Network'
-                  }
-                ],
-                virtv2v_started_on: '2018-04-06 08:35:45',
-                virtv2v_status: 'active',
-                virtv2v_wrapper: {
-                  state_file: '/tmp/v2v-import-20180406T083602-116599.state',
-                  v2v_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599.log',
-                  wrapper_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599-wrapper.log'
-                },
-                workflow_settings: {
-                  resource_action_id: '22'
-                }
-              },
-              phase: null,
-              phase_context: {},
-              request_state: '<SOMETHING>',
-              request_type: 'transformation_plan',
-              source_id: '27',
-              source_type: 'VmOrTemplate',
-              state: 'finished',
-              status: 'Ok',
-              tenant_id: '1',
-              type: 'ServiceTemplateTransformationPlanTask',
-              updated_on: '2018-04-06T12:49:30Z',
-              userid: 'admin'
-            }
-          ]
+            initiator: null,
+            src_id: '30',
+            cart_state: 'ordered',
+            requester_group: 'EvmGroup-super_administrator'
+          },
+          userid: 'admin',
+          source_id: '30',
+          source_type: 'ServiceTemplate',
+          destination_id: null,
+          destination_type: null,
+          tenant_id: '1',
+          service_order_id: '91',
+          process: true
         }
       ]
     },
     // PLAN D-0 FAILED
     // |-- Request 1: failed
-    // |---- Task 1: succeed
-    // |---- Task 2: failed
     {
       href: 'http://localhost:3000/api/service_templates/40',
-      id: '40',
       name: 'Migration Plan D-0',
-      description: '',
-      guid: 'c25a2094-8e80-4265-ac6f-6d12dff7bfda',
-      type: 'ServiceTemplateTransformationPlan',
-      service_template_id: null,
       options: {
         config_info: {
           transformation_mapping_id: '1',
           vm_ids: ['1', '3']
         }
       },
+      created_at: '2018-05-01T12:13:50',
+      id: '40',
       miq_requests: [
         {
           href: 'http://localhost:3000/api/service_requests/4000',
           id: '4000',
           description: 'Migration Plan D-0',
-          state: '',
           approval_state: 'approved',
-          request_state: 'failed',
-          status: 'Error',
+          type: 'ServiceTemplateTransformationPlanRequest',
           created_on: '2018-04-06T12:31:30Z',
+          updated_on: '2018-04-06T12:31:30Z',
+          fulfilled_on: '2018-04-06T12:31:30Z',
+          requester_id: '1',
+          requester_name: 'Administrator',
+          request_type: 'transformation_plan',
+          request_state: 'finished',
+          message: 'VM Transformations failed',
+          status: 'Error',
           options: {
-            src_id: '6',
-            cart_state: 'ordered',
-            delivered_on: '2018-04-06T12:49:30Z', // can use this timestamp as the starting time for this request
-            user_message: '[EVM] VM Migrated Successfully'
-          },
-          miq_request_tasks: [
-            {
-              created_on: '2018-04-06T12:31:30Z',
-              description: 'Transforming VM [test_migration]',
-              destination_id: null,
-              destination_type: null,
-              href: 'http://localhost:3000/api/request_tasks/400',
-              id: '400',
-              message: 'VM Transformations completed',
-              miq_request_id: '400',
-              miq_request_task_id: null,
-              options: {
-                cart_state: 'ordered',
-                collapse_snapshots: true,
-                delivered_on: '2018-04-06T12:31:30.871Z',
-                destination_vm_id: '48',
-                dialog: null,
-                export_domain_id: '1',
-                initiator: null,
-                power_off: true,
-                progress: {
-                  current_description: 'Virtual machine migrated',
-                  current_state: '/State7',
-                  percent: 100.0,
-                  states: {
-                    '/State1': {
-                      description: 'Assess Migration',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:31:52Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:32:28Z',
-                      weight: 1
-                    },
-                    '/State2': {
-                      description: 'Acquire Transformation Host',
-                      message: 'State2 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:32:44Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:33:20Z',
-                      weight: 1
-                    },
-                    '/State3': {
-                      description: 'Power off',
-                      message: 'State3 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:33:35Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:06Z',
-                      weight: 1
-                    },
-                    '/State4': {
-                      description: 'Collapse Snapshots',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:34:22Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:53Z',
-                      weight: 1
-                    },
-                    '/State5': {
-                      description: 'Transform VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:09Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:28Z',
-                      weight: 95
-                    },
-                    '/State5/State1': {
-                      description: 'Convert disks',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:24Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:36:16Z',
-                      weight: 1
-                    },
-                    '/State5/State2': {
-                      description: 'Convert disks',
-                      message: 'Disks transformation succeeded.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:36:32Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:40:33Z',
-                      weight: 85
-                    },
-                    '/State5/State4': {
-                      description: 'Identify destination VM',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:40:48Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:07Z',
-                      weight: 4
-                    },
-                    '/State5/State5': {
-                      description: 'Update description of VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:43:23Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:59Z',
-                      weight: 1
-                    },
-                    '/State5/State6': {
-                      description: 'Enable Virtio-SCSI for VM',
-                      message: 'State6 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:44:15Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:44:52Z',
-                      weight: 1
-                    },
-                    '/State5/State8': {
-                      description: 'Power-on VM',
-                      message: 'State8 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:07Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:45:38Z',
-                      weight: 1
-                    },
-                    '/State5/State9': {
-                      description: 'Power-on VM',
-                      message: 'State9 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:54Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:12Z',
-                      weight: 7
-                    },
-                    '/State6': {
-                      description: 'Mark source as migrated',
-                      message: 'exit',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:48:43Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:49:14Z',
-                      weight: 1
-                    },
-                    '/State7': {
-                      description: 'Virtual machine migrated',
-                      message: 'Virtual machine migrated',
-                      percent: 0.0,
-                      started_on: '2018-04-06T12:49:30Z',
-                      status: 'active',
-                      weight: 1
-                    }
-                  }
-                },
-                requester_group: 'EvmGroup-super_administrator',
-                src_id: '2',
-                transformation_host_id: '1',
-                transformation_host_name: 'rhvh01.example.com',
-                virtv2v_disks: [
-                  {
-                    path: '[NFS_Datastore] test_migration/test_migration.vmdk',
-                    percent: 100,
-                    size: 17179869184,
-                    weight: 100
-                  }
-                ],
-                virtv2v_finished_on: '20180406_0840',
-                virtv2v_networks: [
-                  {
-                    destination: 'VM_Network',
-                    source: 'VM Network'
-                  }
-                ],
-                virtv2v_started_on: '2018-04-06 08:35:45',
-                virtv2v_status: 'active',
-                virtv2v_wrapper: {
-                  state_file: '/tmp/v2v-import-20180406T083602-116599.state',
-                  v2v_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599.log',
-                  wrapper_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599-wrapper.log'
-                },
-                workflow_settings: {
-                  resource_action_id: '22'
-                }
-              },
-              phase: null,
-              phase_context: {},
-              request_state: 'Finished',
-              request_type: 'transformation_plan',
-              source_id: '26',
-              source_type: 'VmOrTemplate',
-              state: 'finished',
-              status: 'Ok',
-              tenant_id: '1',
-              type: 'ServiceTemplateTransformationPlanTask',
-              updated_on: '2018-04-06T12:49:30Z',
-              userid: 'admin'
+            dialog: null,
+            workflow_settings: {
+              resource_action_id: '4507'
             },
-            {
-              created_on: '2018-04-06T12:31:30Z',
-              description: 'Transforming VM [test_migration]',
-              destination_id: null,
-              destination_type: null,
-              href: 'http://localhost:3000/api/request_tasks/401',
-              id: '401',
-              message: 'VM Transformations completed',
-              miq_request_id: '401',
-              miq_request_task_id: null,
-              options: {
-                cart_state: 'ordered',
-                collapse_snapshots: true,
-                delivered_on: '2018-04-06T12:31:30.871Z',
-                destination_vm_id: '48',
-                dialog: null,
-                export_domain_id: '1',
-                initiator: null,
-                power_off: true,
-                progress: {
-                  current_description: '<SOMETHING>',
-                  current_state: '/State7',
-                  percent: 100.0,
-                  states: {
-                    '/State1': {
-                      description: 'Assess Migration',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:31:52Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:32:28Z',
-                      weight: 1
-                    },
-                    '/State2': {
-                      description: 'Acquire Transformation Host',
-                      message: 'State2 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:32:44Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:33:20Z',
-                      weight: 1
-                    },
-                    '/State3': {
-                      description: 'Power off',
-                      message: 'State3 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:33:35Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:06Z',
-                      weight: 1
-                    },
-                    '/State4': {
-                      description: 'Collapse Snapshots',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:34:22Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:53Z',
-                      weight: 1
-                    },
-                    '/State5': {
-                      description: 'Transform VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:09Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:28Z',
-                      weight: 95
-                    },
-                    '/State5/State1': {
-                      description: 'Convert disks',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:24Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:36:16Z',
-                      weight: 1
-                    },
-                    '/State5/State2': {
-                      description: 'Convert disks',
-                      message: 'Disks transformation succeeded.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:36:32Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:40:33Z',
-                      weight: 85
-                    },
-                    '/State5/State4': {
-                      description: 'Identify destination VM',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:40:48Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:07Z',
-                      weight: 4
-                    },
-                    '/State5/State5': {
-                      description: 'Update description of VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:43:23Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:59Z',
-                      weight: 1
-                    },
-                    '/State5/State6': {
-                      description: 'Enable Virtio-SCSI for VM',
-                      message: 'State6 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:44:15Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:44:52Z',
-                      weight: 1
-                    },
-                    '/State5/State8': {
-                      description: 'Power-on VM',
-                      message: 'State8 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:07Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:45:38Z',
-                      weight: 1
-                    },
-                    '/State5/State9': {
-                      description: 'Power-on VM',
-                      message: 'State9 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:54Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:12Z',
-                      weight: 7
-                    },
-                    '/State6': {
-                      description: 'Mark source as migrated',
-                      message: 'exit',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:48:43Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:49:14Z',
-                      weight: 1
-                    },
-                    '/State7': {
-                      description: 'Virtual machine migrated',
-                      message: 'Virtual machine migrated',
-                      percent: 0.0,
-                      started_on: '2018-04-06T12:49:30Z',
-                      status: 'active',
-                      weight: 1
-                    }
-                  }
-                },
-                requester_group: 'EvmGroup-super_administrator',
-                src_id: '2',
-                transformation_host_id: '1',
-                transformation_host_name: 'rhvh01.example.com',
-                virtv2v_disks: [
-                  {
-                    path: '[NFS_Datastore] test_migration/test_migration.vmdk',
-                    percent: 100,
-                    size: 17179869184,
-                    weight: 100
-                  }
-                ],
-                virtv2v_finished_on: '20180406_0840',
-                virtv2v_networks: [
-                  {
-                    destination: 'VM_Network',
-                    source: 'VM Network'
-                  }
-                ],
-                virtv2v_started_on: '2018-04-06 08:35:45',
-                virtv2v_status: 'active',
-                virtv2v_wrapper: {
-                  state_file: '/tmp/v2v-import-20180406T083602-116599.state',
-                  v2v_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599.log',
-                  wrapper_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599-wrapper.log'
-                },
-                workflow_settings: {
-                  resource_action_id: '22'
-                }
-              },
-              phase: null,
-              phase_context: {},
-              request_state: 'Finished',
-              request_type: 'transformation_plan',
-              source_id: '26',
-              source_type: 'VmOrTemplate',
-              state: 'finished',
-              status: '<REQUEST_TASK_FAILED>',
-              tenant_id: '1',
-              type: 'ServiceTemplateTransformationPlanTask',
-              updated_on: '2018-04-06T12:49:30Z',
-              userid: 'admin'
-            }
-          ]
+            initiator: null,
+            src_id: '40',
+            cart_state: 'ordered',
+            requester_group: 'EvmGroup-super_administrator',
+            delivered_on: '2018-05-01T12:13:58.754'
+          },
+          userid: 'admin',
+          source_id: '40',
+          source_type: 'ServiceTemplate',
+          destination_id: null,
+          destination_type: null,
+          tenant_id: '1',
+          service_order_id: '91',
+          process: true
         }
       ]
     },
     // PLAN E-0 COMPLETE
     // |-- Request 1: complete
-    // |---- Task 1: succeed
-    // |---- Task 2: succeed
     {
       href: 'http://localhost:3000/api/service_templates/50',
-      id: '50',
       name: 'Migration Plan E-0',
-      description: '',
-      guid: 'fbadaa16-041d-4ebe-ba3d-8eea9c65db48',
-      type: 'ServiceTemplateTransformationPlan',
-      service_template_id: null,
       options: {
         config_info: {
           transformation_mapping_id: '1',
           vm_ids: ['1', '3']
         }
       },
+      created_at: '2018-05-01T12:13:50Z',
+      id: '50',
       miq_requests: [
         {
           href: 'http://localhost:3000/api/service_requests/5000',
           id: '5000',
           description: 'Migration Plan E-0',
-          state: '',
           approval_state: 'approved',
-          status: 'Ok',
-          request_state: 'finished',
+          type: 'ServiceTemplateTransformationPlanRequest',
           created_on: '2018-04-06T12:31:30Z',
+          updated_on: '2018-04-06T12:31:30Z',
+          fulfilled_on: '2018-04-06T12:31:30Z',
+          requester_id: '1',
+          requester_name: 'Administrator',
+          request_type: 'transformation_plan',
+          request_state: 'finished',
+          message: 'VM Transformations <SOMETHING>',
+          status: 'Ok',
           options: {
-            src_id: '6',
-            cart_state: 'ordered',
-            delivered_on: '2018-04-06T12:49:30Z', // can use this timestamp as the starting time for this request
-            user_message: '[EVM] VM Migrated Successfully'
-          },
-          miq_request_tasks: [
-            {
-              created_on: '2018-04-06T12:31:30Z',
-              description: 'Transforming VM [test_migration]',
-              destination_id: null,
-              destination_type: null,
-              href: 'http://localhost:3000/api/request_tasks/500',
-              id: '500',
-              message: 'VM Transformations completed',
-              miq_request_id: '500',
-              miq_request_task_id: null,
-              options: {
-                cart_state: 'ordered',
-                collapse_snapshots: true,
-                delivered_on: '2018-04-06T12:31:30.871Z',
-                destination_vm_id: '48',
-                dialog: null,
-                export_domain_id: '1',
-                initiator: null,
-                power_off: true,
-                progress: {
-                  current_description: 'Virtual machine migrated',
-                  current_state: '/State7',
-                  percent: 100.0,
-                  states: {
-                    '/State1': {
-                      description: 'Assess Migration',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:31:52Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:32:28Z',
-                      weight: 1
-                    },
-                    '/State2': {
-                      description: 'Acquire Transformation Host',
-                      message: 'State2 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:32:44Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:33:20Z',
-                      weight: 1
-                    },
-                    '/State3': {
-                      description: 'Power off',
-                      message: 'State3 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:33:35Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:06Z',
-                      weight: 1
-                    },
-                    '/State4': {
-                      description: 'Collapse Snapshots',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:34:22Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:53Z',
-                      weight: 1
-                    },
-                    '/State5': {
-                      description: 'Transform VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:09Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:28Z',
-                      weight: 95
-                    },
-                    '/State5/State1': {
-                      description: 'Convert disks',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:24Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:36:16Z',
-                      weight: 1
-                    },
-                    '/State5/State2': {
-                      description: 'Convert disks',
-                      message: 'Disks transformation succeeded.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:36:32Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:40:33Z',
-                      weight: 85
-                    },
-                    '/State5/State4': {
-                      description: 'Identify destination VM',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:40:48Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:07Z',
-                      weight: 4
-                    },
-                    '/State5/State5': {
-                      description: 'Update description of VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:43:23Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:59Z',
-                      weight: 1
-                    },
-                    '/State5/State6': {
-                      description: 'Enable Virtio-SCSI for VM',
-                      message: 'State6 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:44:15Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:44:52Z',
-                      weight: 1
-                    },
-                    '/State5/State8': {
-                      description: 'Power-on VM',
-                      message: 'State8 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:07Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:45:38Z',
-                      weight: 1
-                    },
-                    '/State5/State9': {
-                      description: 'Power-on VM',
-                      message: 'State9 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:54Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:12Z',
-                      weight: 7
-                    },
-                    '/State6': {
-                      description: 'Mark source as migrated',
-                      message: 'exit',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:48:43Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:49:14Z',
-                      weight: 1
-                    },
-                    '/State7': {
-                      description: 'Virtual machine migrated',
-                      message: 'Virtual machine migrated',
-                      percent: 0.0,
-                      started_on: '2018-04-06T12:49:30Z',
-                      status: 'active',
-                      weight: 1
-                    }
-                  }
-                },
-                requester_group: 'EvmGroup-super_administrator',
-                src_id: '2',
-                transformation_host_id: '1',
-                transformation_host_name: 'rhvh01.example.com',
-                virtv2v_disks: [
-                  {
-                    path: '[NFS_Datastore] test_migration/test_migration.vmdk',
-                    percent: 100,
-                    size: 17179869184,
-                    weight: 100
-                  }
-                ],
-                virtv2v_finished_on: '20180406_0840',
-                virtv2v_networks: [
-                  {
-                    destination: 'VM_Network',
-                    source: 'VM Network'
-                  }
-                ],
-                virtv2v_started_on: '2018-04-06 08:35:45',
-                virtv2v_status: 'active',
-                virtv2v_wrapper: {
-                  state_file: '/tmp/v2v-import-20180406T083602-116599.state',
-                  v2v_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599.log',
-                  wrapper_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599-wrapper.log'
-                },
-                workflow_settings: {
-                  resource_action_id: '22'
-                }
-              },
-              phase: null,
-              phase_context: {},
-              request_state: 'Finished',
-              request_type: 'transformation_plan',
-              source_id: '26',
-              source_type: 'VmOrTemplate',
-              state: 'finished',
-              status: 'Ok',
-              tenant_id: '1',
-              type: 'ServiceTemplateTransformationPlanTask',
-              updated_on: '2018-04-06T12:49:30Z',
-              userid: 'admin'
+            dialog: null,
+            workflow_settings: {
+              resource_action_id: '4507'
             },
-            {
-              created_on: '2018-04-06T12:31:30Z',
-              description: 'Transforming VM [test_migration]',
-              destination_id: null,
-              destination_type: null,
-              href: 'http://localhost:3000/api/request_tasks/501',
-              id: '501',
-              message: 'VM Transformations completed',
-              miq_request_id: '501',
-              miq_request_task_id: null,
-              options: {
-                cart_state: 'ordered',
-                collapse_snapshots: true,
-                delivered_on: '2018-04-06T12:31:30.871Z',
-                destination_vm_id: '48',
-                dialog: null,
-                export_domain_id: '1',
-                initiator: null,
-                power_off: true,
-                progress: {
-                  current_description: 'Virtual machine migrated',
-                  current_state: '/State7',
-                  percent: 100.0,
-                  states: {
-                    '/State1': {
-                      description: 'Assess Migration',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:31:52Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:32:28Z',
-                      weight: 1
-                    },
-                    '/State2': {
-                      description: 'Acquire Transformation Host',
-                      message: 'State2 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:32:44Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:33:20Z',
-                      weight: 1
-                    },
-                    '/State3': {
-                      description: 'Power off',
-                      message: 'State3 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:33:35Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:06Z',
-                      weight: 1
-                    },
-                    '/State4': {
-                      description: 'Collapse Snapshots',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:34:22Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:53Z',
-                      weight: 1
-                    },
-                    '/State5': {
-                      description: 'Transform VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:09Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:28Z',
-                      weight: 95
-                    },
-                    '/State5/State1': {
-                      description: 'Convert disks',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:24Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:36:16Z',
-                      weight: 1
-                    },
-                    '/State5/State2': {
-                      description: 'Convert disks',
-                      message: 'Disks transformation succeeded.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:36:32Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:40:33Z',
-                      weight: 85
-                    },
-                    '/State5/State4': {
-                      description: 'Identify destination VM',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:40:48Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:07Z',
-                      weight: 4
-                    },
-                    '/State5/State5': {
-                      description: 'Update description of VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:43:23Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:59Z',
-                      weight: 1
-                    },
-                    '/State5/State6': {
-                      description: 'Enable Virtio-SCSI for VM',
-                      message: 'State6 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:44:15Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:44:52Z',
-                      weight: 1
-                    },
-                    '/State5/State8': {
-                      description: 'Power-on VM',
-                      message: 'State8 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:07Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:45:38Z',
-                      weight: 1
-                    },
-                    '/State5/State9': {
-                      description: 'Power-on VM',
-                      message: 'State9 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:54Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:12Z',
-                      weight: 7
-                    },
-                    '/State6': {
-                      description: 'Mark source as migrated',
-                      message: 'exit',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:48:43Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:49:14Z',
-                      weight: 1
-                    },
-                    '/State7': {
-                      description: 'Virtual machine migrated',
-                      message: 'Virtual machine migrated',
-                      percent: 0.0,
-                      started_on: '2018-04-06T12:49:30Z',
-                      status: 'active',
-                      weight: 1
-                    }
-                  }
-                },
-                requester_group: 'EvmGroup-super_administrator',
-                src_id: '2',
-                transformation_host_id: '1',
-                transformation_host_name: 'rhvh01.example.com',
-                virtv2v_disks: [
-                  {
-                    path: '[NFS_Datastore] test_migration/test_migration.vmdk',
-                    percent: 100,
-                    size: 17179869184,
-                    weight: 100
-                  }
-                ],
-                virtv2v_finished_on: '20180406_0840',
-                virtv2v_networks: [
-                  {
-                    destination: 'VM_Network',
-                    source: 'VM Network'
-                  }
-                ],
-                virtv2v_started_on: '2018-04-06 08:35:45',
-                virtv2v_status: 'active',
-                virtv2v_wrapper: {
-                  state_file: '/tmp/v2v-import-20180406T083602-116599.state',
-                  v2v_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599.log',
-                  wrapper_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599-wrapper.log'
-                },
-                workflow_settings: {
-                  resource_action_id: '22'
-                }
-              },
-              phase: null,
-              phase_context: {},
-              request_state: 'Finished',
-              request_type: 'transformation_plan',
-              source_id: '26',
-              source_type: 'VmOrTemplate',
-              state: 'finished',
-              status: 'Ok',
-              tenant_id: '1',
-              type: 'ServiceTemplateTransformationPlanTask',
-              updated_on: '2018-04-06T12:49:30Z',
-              userid: 'admin'
-            }
-          ]
+            initiator: null,
+            src_id: '50',
+            cart_state: 'ordered',
+            requester_group: 'EvmGroup-super_administrator',
+            delivered_on: '2018-04-06T12:49:30Z'
+          },
+          userid: 'admin',
+          source_id: '50',
+          source_type: 'ServiceTemplate',
+          destination_id: null,
+          destination_type: null,
+          tenant_id: '1',
+          service_order_id: '91',
+          process: true
         }
       ]
     },
     // PLAN F-0 APPROVED
     // |-- Request 1: active
-    // |---- Task 1: active
-    // |---- Task 2: failed
     {
       href: 'http://localhost:3000/api/service_templates/60',
-      id: '60',
       name: 'Migration Plan F-0',
-      description: '',
-      guid: '1f49ea91-8503-4d0c-a3b3-c6958bd95a5d',
-      type: 'ServiceTemplateTransformationPlan',
-      service_template_id: null,
       options: {
         config_info: {
           transformation_mapping_id: '1',
           vm_ids: ['1', '3']
         }
       },
+      created_at: '2018-05-01T12:13:50Z',
+      id: '60',
       miq_requests: [
         {
           href: 'http://localhost:3000/api/service_requests/6000',
           id: '6000',
           description: 'Migration Plan F-0',
-          state: '',
           approval_state: 'approved',
-          request_state: 'active',
-          status: 'Ok',
+          type: 'ServiceTemplateTransformationPlanRequest',
           created_on: '2018-04-06T12:31:30Z',
+          updated_on: '2018-04-06T12:31:30Z',
+          fulfilled_on: '2018-04-06T12:31:30Z',
+          requester_id: '1',
+          requester_name: 'Administrator',
+          request_type: 'transformation_plan',
+          request_state: 'active',
+          message: 'VM Transformations <SOMETHING>',
+          status: 'Ok',
           options: {
-            src_id: '6',
-            cart_state: 'ordered',
-            delivered_on: '2018-04-06T12:49:30Z', // can use this timestamp as the starting time for this request
-            user_message: '[EVM] VM Migrated Successfully'
-          },
-          miq_request_tasks: [
-            {
-              created_on: '2018-04-06T12:31:30Z',
-              description: 'Transforming VM [test_migration]',
-              destination_id: null,
-              destination_type: null,
-              href: 'http://localhost:3000/api/request_tasks/600',
-              id: '600',
-              message: 'Migrating',
-              miq_request_id: '600',
-              miq_request_task_id: null,
-              options: {
-                cart_state: 'ordered',
-                collapse_snapshots: true,
-                delivered_on: '2018-04-06T12:31:30.871Z',
-                destination_vm_id: '48',
-                dialog: null,
-                export_domain_id: '1',
-                initiator: null,
-                power_off: true,
-                progress: {
-                  current_description: '<SOMETHING>',
-                  current_state: '/State7',
-                  percent: 100.0,
-                  states: {
-                    '/State1': {
-                      description: 'Assess Migration',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:31:52Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:32:28Z',
-                      weight: 1
-                    },
-                    '/State2': {
-                      description: 'Acquire Transformation Host',
-                      message: 'State2 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:32:44Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:33:20Z',
-                      weight: 1
-                    },
-                    '/State3': {
-                      description: 'Power off',
-                      message: 'State3 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:33:35Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:06Z',
-                      weight: 1
-                    },
-                    '/State4': {
-                      description: 'Collapse Snapshots',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:34:22Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:53Z',
-                      weight: 1
-                    },
-                    '/State5': {
-                      description: 'Transform VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:09Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:28Z',
-                      weight: 95
-                    },
-                    '/State5/State1': {
-                      description: 'Convert disks',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:24Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:36:16Z',
-                      weight: 1
-                    },
-                    '/State5/State2': {
-                      description: 'Convert disks',
-                      message: 'Disks transformation succeeded.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:36:32Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:40:33Z',
-                      weight: 85
-                    },
-                    '/State5/State4': {
-                      description: 'Identify destination VM',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:40:48Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:07Z',
-                      weight: 4
-                    },
-                    '/State5/State5': {
-                      description: 'Update description of VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:43:23Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:59Z',
-                      weight: 1
-                    },
-                    '/State5/State6': {
-                      description: 'Enable Virtio-SCSI for VM',
-                      message: 'State6 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:44:15Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:44:52Z',
-                      weight: 1
-                    },
-                    '/State5/State8': {
-                      description: 'Power-on VM',
-                      message: 'State8 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:07Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:45:38Z',
-                      weight: 1
-                    },
-                    '/State5/State9': {
-                      description: 'Power-on VM',
-                      message: 'State9 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:54Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:12Z',
-                      weight: 7
-                    },
-                    '/State6': {
-                      description: 'Mark source as migrated',
-                      message: 'exit',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:48:43Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:49:14Z',
-                      weight: 1
-                    },
-                    '/State7': {
-                      description: 'Virtual machine migrated',
-                      message: 'Virtual machine migrated',
-                      percent: 0.0,
-                      started_on: '2018-04-06T12:49:30Z',
-                      status: 'active',
-                      weight: 1
-                    }
-                  }
-                },
-                requester_group: 'EvmGroup-super_administrator',
-                src_id: '2',
-                transformation_host_id: '1',
-                transformation_host_name: 'rhvh01.example.com',
-                virtv2v_disks: [
-                  {
-                    path: '[NFS_Datastore] test_migration/test_migration.vmdk',
-                    percent: 60,
-                    size: 17179869184,
-                    weight: 100
-                  }
-                ],
-                virtv2v_finished_on: '20180406_0840',
-                virtv2v_networks: [
-                  {
-                    destination: 'VM_Network',
-                    source: 'VM Network'
-                  }
-                ],
-                virtv2v_started_on: '2018-04-06 08:35:45',
-                virtv2v_status: 'active',
-                virtv2v_wrapper: {
-                  state_file: '/tmp/v2v-import-20180406T083602-116599.state',
-                  v2v_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599.log',
-                  wrapper_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599-wrapper.log'
-                },
-                workflow_settings: {
-                  resource_action_id: '22'
-                }
-              },
-              phase: null,
-              phase_context: {},
-              request_state: '<SOMETHING>',
-              request_type: 'transformation_plan',
-              source_id: '28',
-              source_type: 'VmOrTemplate',
-              state: 'active',
-              status: 'Ok',
-              tenant_id: '1',
-              type: 'ServiceTemplateTransformationPlanTask',
-              updated_on: '2018-04-06T12:49:30Z',
-              userid: 'admin'
+            dialog: null,
+            workflow_settings: {
+              resource_action_id: '2507'
             },
-            {
-              created_on: '2018-04-06T12:31:30Z',
-              description: 'Transforming VM [test_migration]',
-              destination_id: null,
-              destination_type: null,
-              href: 'http://localhost:3000/api/request_tasks/601',
-              id: '601',
-              message: 'VM Transformations completed',
-              miq_request_id: '601',
-              miq_request_task_id: null,
-              options: {
-                cart_state: 'ordered',
-                collapse_snapshots: true,
-                delivered_on: '2018-04-06T12:31:30.871Z',
-                destination_vm_id: '48',
-                dialog: null,
-                export_domain_id: '1',
-                initiator: null,
-                power_off: true,
-                progress: {
-                  current_description: '<SOMETHING>',
-                  current_state: '/State7',
-                  percent: 100.0,
-                  states: {
-                    '/State1': {
-                      description: 'Assess Migration',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:31:52Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:32:28Z',
-                      weight: 1
-                    },
-                    '/State2': {
-                      description: 'Acquire Transformation Host',
-                      message: 'State2 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:32:44Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:33:20Z',
-                      weight: 1
-                    },
-                    '/State3': {
-                      description: 'Power off',
-                      message: 'State3 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:33:35Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:06Z',
-                      weight: 1
-                    },
-                    '/State4': {
-                      description: 'Collapse Snapshots',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:34:22Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:34:53Z',
-                      weight: 1
-                    },
-                    '/State5': {
-                      description: 'Transform VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:09Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:28Z',
-                      weight: 95
-                    },
-                    '/State5/State1': {
-                      description: 'Convert disks',
-                      message: 'State1 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:35:24Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:36:16Z',
-                      weight: 1
-                    },
-                    '/State5/State2': {
-                      description: 'Convert disks',
-                      message: 'Disks transformation succeeded.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:36:32Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:40:33Z',
-                      weight: 85
-                    },
-                    '/State5/State4': {
-                      description: 'Identify destination VM',
-                      message: 'State4 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:40:48Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:07Z',
-                      weight: 4
-                    },
-                    '/State5/State5': {
-                      description: 'Update description of VM',
-                      message: 'State5 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:43:23Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:43:59Z',
-                      weight: 1
-                    },
-                    '/State5/State6': {
-                      description: 'Enable Virtio-SCSI for VM',
-                      message: 'State6 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:44:15Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:44:52Z',
-                      weight: 1
-                    },
-                    '/State5/State8': {
-                      description: 'Power-on VM',
-                      message: 'State8 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:07Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:45:38Z',
-                      weight: 1
-                    },
-                    '/State5/State9': {
-                      description: 'Power-on VM',
-                      message: 'State9 is finished.',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:45:54Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:48:12Z',
-                      weight: 7
-                    },
-                    '/State6': {
-                      description: 'Mark source as migrated',
-                      message: 'exit',
-                      percent: 100.0,
-                      started_on: '2018-04-06T12:48:43Z',
-                      status: 'finished',
-                      updated_on: '2018-04-06T12:49:14Z',
-                      weight: 1
-                    },
-                    '/State7': {
-                      description: 'Virtual machine migrated',
-                      message: 'Virtual machine migrated',
-                      percent: 0.0,
-                      started_on: '2018-04-06T12:49:30Z',
-                      status: 'active',
-                      weight: 1
-                    }
-                  }
-                },
-                requester_group: 'EvmGroup-super_administrator',
-                src_id: '2',
-                transformation_host_id: '1',
-                transformation_host_name: 'rhvh01.example.com',
-                virtv2v_disks: [
-                  {
-                    path: '[NFS_Datastore] test_migration/test_migration.vmdk',
-                    percent: 0,
-                    size: 17179869184,
-                    weight: 100
-                  }
-                ],
-                virtv2v_finished_on: '20180406_0840',
-                virtv2v_networks: [
-                  {
-                    destination: 'VM_Network',
-                    source: 'VM Network'
-                  }
-                ],
-                virtv2v_started_on: '2018-04-06 08:35:45',
-                virtv2v_status: 'active',
-                virtv2v_wrapper: {
-                  state_file: '/tmp/v2v-import-20180406T083602-116599.state',
-                  v2v_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599.log',
-                  wrapper_log:
-                    '/var/log/vdsm/import/v2v-import-20180406T083602-116599-wrapper.log'
-                },
-                workflow_settings: {
-                  resource_action_id: '22'
-                }
-              },
-              phase: null,
-              phase_context: {},
-              request_state: 'Finished',
-              request_type: 'transformation_plan',
-              source_id: '26',
-              source_type: 'VmOrTemplate',
-              state: 'finished',
-              status: 'Error',
-              tenant_id: '1',
-              type: 'ServiceTemplateTransformationPlanTask',
-              updated_on: '2018-04-06T12:49:30Z',
-              userid: 'admin'
-            }
-          ]
+            initiator: null,
+            src_id: '60',
+            cart_state: 'ordered',
+            requester_group: 'EvmGroup-super_administrator',
+            delivered_on: '2018-04-06T12:49:30Z'
+          },
+          userid: 'admin',
+          source_id: '60',
+          source_type: 'ServiceTemplate',
+          destination_id: null,
+          destination_type: null,
+          tenant_id: '1',
+          service_order_id: '91',
+          process: true
         }
       ]
     }


### PR DESCRIPTION
Minor code cleanup to keep mockMode aligned with back end

## Notes
1. Fixture adjustments based on the following request
    ```
    http://localhost:3000/api/service_templates/?filter[]=type=ServiceTemplateTransformationPlan&expand=resources&attributes=name,miq_requests,options,created_at
    ```
    ### API Responses
    1. [Queued](https://gist.github.com/michaelkro/e51031c3a5bb44043c02d3e74dac6ee0)
    2. [Pending](https://gist.github.com/michaelkro/766596d82e84202c5630ff248ccb105b)
    3. [Finished (with errors)](https://gist.github.com/michaelkro/0bab1eb109fe6edf9763d4917d06f622)
2. A Jest warning also fixed in this PR.

    ```
      console.error node_modules/fbjs/lib/warning.js:33
      Warning: Failed prop type: Invalid prop `loading` of type `string` supplied to  `MigrationsNotStartedList`, expected `boolean`. in MigrationsNotStartedList

      console.error node_modules/fbjs/lib/warning.js:33
      Warning: Failed prop type: Invalid prop `loading` of type `string` supplied to `Spinner`, expected  `boolean`. in Spinner
    ```

    We use the `href` of a plan as its loading "state" in order to uniquely identify and disable it's `Retry` and `Migrate` buttons.  However, it should be noted that a spinner now obscures the `Migrations Completed` and `Migrations Not Started` sections while loading, so we don't actually need to disable these buttons any more