### PR TITLE
Remove mock mode

### DIFF
--- a/app/javascript/common/API.js
+++ b/app/javascript/common/API.js
@@ -34,5 +34,3 @@ export default {
     });
   }
 };
-
-export const globalMockMode = false;

--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -16,9 +16,6 @@ import LongDateTime from './dates/LongDateTime';
 import RelativeDateTime from './dates/RelativeDateTime';
 import ShortDateTime from './dates/ShortDateTime';
 import MiqV2vUi from '../react';
-import { globalMockMode } from '../common/API';
-
-const mockMode = globalMockMode;
 
 export const coreComponents = [
   {
@@ -31,16 +28,14 @@ export const coreComponents = [
     name: 'MappingWizardClustersStepContainer',
     type: MappingWizardClustersStepContainer,
     data: {
-      fetchSourceClustersUrl: mockMode
-        ? '/api/dummyProviders'
-        : '/api/clusters?expand=resources' +
-          '&attributes=ext_management_system.emstype,v_parent_datacenter' +
-          '&filter[]=ext_management_system.emstype=vmwarews',
-      fetchTargetClustersUrl: mockMode
-        ? '/api/dummyProviders'
-        : '/api/clusters?expand=resources' +
-          '&attributes=ext_management_system.emstype,v_parent_datacenter' +
-          '&filter[]=ext_management_system.emstype=rhevm'
+      fetchSourceClustersUrl:
+        '/api/clusters?expand=resources' +
+        '&attributes=ext_management_system.emstype,v_parent_datacenter' +
+        '&filter[]=ext_management_system.emstype=vmwarews',
+      fetchTargetClustersUrl:
+        '/api/clusters?expand=resources' +
+        '&attributes=ext_management_system.emstype,v_parent_datacenter' +
+        '&filter[]=ext_management_system.emstype=rhevm'
     },
     store: true
   },
@@ -48,7 +43,7 @@ export const coreComponents = [
     name: 'MappingWizardDatastoresStepContainer',
     type: MappingWizardDatastoresStepContainer,
     data: {
-      fetchDatastoresUrl: mockMode ? '/api/dummyClusters' : 'api/clusters'
+      fetchDatastoresUrl: 'api/clusters'
     },
     store: true
   },
@@ -56,7 +51,7 @@ export const coreComponents = [
     name: 'MappingWizardNetworksStepContainer',
     type: MappingWizardNetworksStepContainer,
     data: {
-      fetchNetworksUrl: mockMode ? '/api/dummyClusters' : 'api/clusters'
+      fetchNetworksUrl: 'api/clusters'
     },
     store: true
   },
@@ -64,34 +59,28 @@ export const coreComponents = [
     name: 'MappingWizardResultsStepContainer',
     type: MappingWizardResultsStepContainer,
     data: {
-      postMappingsUrl: mockMode
-        ? '/api/dummyPostMappings'
-        : 'api/transformation_mappings'
+      postMappingsUrl: 'api/transformation_mappings'
     }
   },
   {
     name: 'PlanWizardVMStepContainer',
     type: PlanWizardVMStepContainer,
     data: {
-      validateVmsUrl: mockMode
-        ? '/api/dummyValidateVMUrl'
-        : '/api/transformation_mappings'
+      validateVmsUrl: '/api/transformation_mappings'
     }
   },
   {
     name: 'PlanWizardResultsStepContainer',
     type: PlanWizardResultsStepContainer,
     data: {
-      postPlansUrl: mockMode
-        ? '/api/dummyMigrationPlansAndRequests'
-        : '/api/service_templates'
+      postPlansUrl: '/api/service_templates'
     }
   },
   {
     name: 'PlanWizardContainer',
     type: PlanWizardContainer,
     data: {
-      url: mockMode ? '/api/dummyMigrationPlans' : '/api/migrationPlans'
+      url: '/api/migrationPlans'
     },
     store: true
   },
@@ -99,23 +88,20 @@ export const coreComponents = [
     name: 'OverviewContainer',
     type: OverviewContainer,
     data: {
-      fetchTransformationMappingsUrl: mockMode
-        ? '/api/dummyMappings'
-        : 'api/transformation_mappings?expand=resources' +
-          '&attributes=transformation_mapping_items',
-      fetchTransformationPlansUrl: mockMode
-        ? '/api/dummyTransformationPlans'
-        : '/api/service_templates/?' +
-          "filter[]=type='ServiceTemplateTransformationPlan'" +
-          '&expand=resources' +
-          '&attributes=name,miq_requests,options,created_at' +
-          '&sort_by=updated_at' +
-          '&sort_order=desc',
-      fetchClustersUrl: mockMode
-        ? '/api/dummyClusters'
-        : 'api/clusters/' +
-          '?attributes=v_parent_datacenter' +
-          '&expand=resources'
+      fetchTransformationMappingsUrl:
+        'api/transformation_mappings?expand=resources' +
+        '&attributes=transformation_mapping_items',
+      fetchTransformationPlansUrl:
+        '/api/service_templates/?' +
+        "filter[]=type='ServiceTemplateTransformationPlan'" +
+        '&expand=resources' +
+        '&attributes=name,miq_requests,options,created_at' +
+        '&sort_by=updated_at' +
+        '&sort_order=desc',
+      fetchClustersUrl:
+        'api/clusters/' +
+        '?attributes=v_parent_datacenter' +
+        '&expand=resources'
     },
     store: true
   },
@@ -124,13 +110,9 @@ export const coreComponents = [
     type: PlanContainer,
     data: {
       fetchPlanUrlBuilder: id =>
-        mockMode
-          ? '/api/dummyPlan'
-          : `/api/service_templates/${id}/?attributes=miq_requests`,
+        `/api/service_templates/${id}/?attributes=miq_requests`,
       fetchPlanRequestUrlBuilder: id =>
-        mockMode
-          ? '/api/dummyPlanRequest'
-          : `/api/service_requests/${id}?attributes=miq_request_tasks`
+        `/api/service_requests/${id}?attributes=miq_request_tasks`
     },
     store: true
   },

--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -109,10 +109,8 @@ export const coreComponents = [
     name: 'PlanContainer',
     type: PlanContainer,
     data: {
-      fetchPlanUrlBuilder: id =>
-        `/api/service_templates/${id}/?attributes=miq_requests`,
-      fetchPlanRequestUrlBuilder: id =>
-        `/api/service_requests/${id}?attributes=miq_request_tasks`
+      fetchPlanUrl: '/api/service_templates',
+      fetchPlanRequestUrl: '/api/service_requests'
     },
     store: true
   },

--- a/app/javascript/react/screens/App/Overview/OverviewActions.js
+++ b/app/javascript/react/screens/App/Overview/OverviewActions.js
@@ -1,5 +1,5 @@
 import URI from 'urijs';
-import API, { globalMockMode } from '../../../../common/API';
+import API from '../../../../common/API';
 
 import {
   SHOW_MAPPING_WIZARD,
@@ -12,16 +12,6 @@ import {
   V2V_FETCH_CLUSTERS,
   V2V_SET_MIGRATIONS_FILTER
 } from './OverviewConstants';
-
-import {
-  requestTransformationMappingsData,
-  createTransformationPlanRequestData
-} from './overview.fixtures';
-import { requestTransformationPlansData } from './overview.transformationPlans.fixtures';
-import { requestRequestsWithTasks } from './overview.requestWithTasks.fixtures';
-import { requestClustersData } from './overview.clusters.fixtures';
-
-const mockMode = globalMockMode;
 
 export const showMappingWizardAction = () => dispatch => {
   dispatch({
@@ -43,13 +33,6 @@ const _createTransformationPlanRequestActionCreator = url => dispatch =>
       promise: API.post(url, { action: 'order' }),
       data: url
     }
-  }).catch(error => {
-    if (mockMode) {
-      dispatch({
-        type: `${CREATE_V2V_TRANSFORMATION_PLAN_REQUEST}_FULFILLED`,
-        payload: createTransformationPlanRequestData.response
-      });
-    }
   });
 
 export const createTransformationPlanRequestAction = url => {
@@ -57,21 +40,11 @@ export const createTransformationPlanRequestAction = url => {
   return _createTransformationPlanRequestActionCreator(uri.toString());
 };
 
-const _getTransformationMappingsActionCreator = url => dispatch => {
+const _getTransformationMappingsActionCreator = url => dispatch =>
   dispatch({
     type: FETCH_V2V_TRANSFORMATION_MAPPINGS,
     payload: API.get(url)
-  }).catch(error => {
-    // to enable UI development without the backend ready, i'm catching the error
-    // and passing some mock data thru the FULFILLED action after the REJECTED action is finished.
-    if (mockMode) {
-      dispatch({
-        type: `${FETCH_V2V_TRANSFORMATION_MAPPINGS}_FULFILLED`,
-        payload: requestTransformationMappingsData.response
-      });
-    }
   });
-};
 
 export const fetchTransformationMappingsAction = url => {
   const uri = new URI(url);
@@ -101,7 +74,7 @@ const collectAllRequests = plan =>
 
 const _getTransformationPlansActionCreator = url => dispatch =>
   dispatch({
-    type: 'FETCH_V2V_TRANSFORMATION_PLANS',
+    type: FETCH_V2V_TRANSFORMATION_PLANS,
     payload: new Promise((resolve, reject) => {
       API.get(url)
         .then(response => {
@@ -119,23 +92,6 @@ const _getTransformationPlansActionCreator = url => dispatch =>
         })
         .catch(e => reject(e));
     })
-  }).catch(error => {
-    // redux-promise-middleware will automatically send:
-    // FETCH_V2V_TRANSFORMATION_PLANS_PENDING, FETCH_V2V_TRANSFORMATION_PLANS_FULFILLED,
-    // FETCH_V2V_TRANSFORMATION_PLANS_REJECTED
-
-    // to enable UI development without the database, i'm catching the error
-    // and passing some mock data thru the FULFILLED action after the REJECTED action is finished.
-    if (mockMode) {
-      dispatch({
-        type: `${FETCH_V2V_TRANSFORMATION_PLANS}_FULFILLED`,
-        payload: requestTransformationPlansData.response
-      });
-      dispatch({
-        type: `${FETCH_V2V_ALL_REQUESTS_WITH_TASKS}_FULFILLED`,
-        payload: requestRequestsWithTasks.response
-      });
-    }
   });
 
 export const fetchTransformationPlansAction = url => {
@@ -157,13 +113,6 @@ const _getClustersActionCreator = url => dispatch =>
   dispatch({
     type: `${V2V_FETCH_CLUSTERS}`,
     payload: API.get(url)
-  }).catch(error => {
-    if (mockMode) {
-      dispatch({
-        type: `${V2V_FETCH_CLUSTERS}_FULFILLED`,
-        payload: requestClustersData.response
-      });
-    }
   });
 
 export const fetchClustersAction = url => {

--- a/app/javascript/react/screens/App/Overview/__test__/__snapshots__/OverviewActions.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/__test__/__snapshots__/OverviewActions.test.js.snap
@@ -37,3 +37,16 @@ Array [
   },
 ]
 `;
+
+exports[`fetchTransformationPlansAction dispatches PENDING and REJECTED actions 1`] = `
+Array [
+  Object {
+    "type": "FETCH_V2V_TRANSFORMATION_PLANS_PENDING",
+  },
+  Object {
+    "error": true,
+    "payload": [Error: Request failed with status code 404],
+    "type": "FETCH_V2V_TRANSFORMATION_PLANS_REJECTED",
+  },
+]
+`;

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepActions.js
@@ -1,33 +1,14 @@
 import URI from 'urijs';
-import API, { globalMockMode } from '../../../../../../../../common/API';
+import API from '../../../../../../../../common/API';
 import {
   FETCH_V2V_SOURCE_CLUSTERS,
   FETCH_V2V_TARGET_CLUSTERS
 } from './MappingWizardClustersStepConstants';
 
-import {
-  requestSourceClustersData,
-  requestTargetClustersData
-} from './mappingWizardClustersStep.fixtures';
-
-const mockMode = globalMockMode;
-
 const _getSourceClustersActionCreator = url => dispatch =>
   dispatch({
     type: FETCH_V2V_SOURCE_CLUSTERS,
     payload: API.get(url)
-  }).catch(error => {
-    // redux-promise-middleware will automatically send:
-    // FETCH_V2V_SOURCE_CLUSTERS_PENDING, FETCH_V2V_SOURCE_CLUSTERS_FULFILLED, FETCH_V2V_SOURCE_CLUSTERS_REJECTED
-
-    // to enable UI development without the backend ready, i'm catching the error
-    // and passing some mock data thru the FULFILLED action after the REJECTED action is finished.
-    if (mockMode) {
-      dispatch({
-        type: `${FETCH_V2V_SOURCE_CLUSTERS}_FULFILLED`,
-        payload: requestSourceClustersData.response
-      });
-    }
   });
 
 export const fetchSourceClustersAction = url => {
@@ -39,18 +20,6 @@ const _getTargetClustersActionCreator = url => dispatch =>
   dispatch({
     type: FETCH_V2V_TARGET_CLUSTERS,
     payload: API.get(url)
-  }).catch(error => {
-    // redux-promise-middleware will automatically send:
-    // FETCH_V2V_TARGET_CLUSTERS_PENDING, FETCH_V2V_TARGET_CLUSTERS_FULFILLED, FETCH_V2V_TARGET_CLUSTERS_REJECTED
-
-    // to enable UI development without the backend ready, i'm catching the error
-    // and passing some mock data thru the FULFILLED action after the REJECTED action is finished.
-    if (mockMode) {
-      dispatch({
-        type: `${FETCH_V2V_TARGET_CLUSTERS}_FULFILLED`,
-        payload: requestTargetClustersData.response
-      });
-    }
   });
 
 export const fetchTargetClustersAction = url => {

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/MappingWizardClusterStepActions.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/MappingWizardClusterStepActions.test.js
@@ -42,7 +42,7 @@ describe('mappingWizard actions', () => {
     });
     return store
       .dispatch(actions.fetchSourceClustersAction(fetchSourceClustersUrl))
-      .then(() => {
+      .catch(() => {
         expect(store.getActions()).toMatchSnapshot();
       });
   });
@@ -67,7 +67,7 @@ describe('mappingWizard actions', () => {
     });
     return store
       .dispatch(actions.fetchTargetClustersAction(fetchTargetClustersUrl))
-      .then(() => {
+      .catch(() => {
         expect(store.getActions()).toMatchSnapshot();
       });
   });

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
@@ -1,15 +1,9 @@
 import URI from 'urijs';
-import API, { globalMockMode } from '../../../../../../../../common/API';
+import API from '../../../../../../../../common/API';
 import {
   FETCH_V2V_SOURCE_DATASTORES,
   FETCH_V2V_TARGET_DATASTORES
 } from './MappingWizardDatastoresStepConstants';
-import {
-  requestSourceDatastoresData,
-  requestTargetDatastoresData
-} from './mappingWizardDatastoresStep.fixtures';
-
-const mockMode = globalMockMode;
 
 const _filterSourceDatastores = response => {
   const { data } = response;
@@ -23,7 +17,7 @@ const _filterSourceDatastores = response => {
   };
 };
 
-const _getSourceDatastoresActionCreator = (url, id) => dispatch => {
+const _getSourceDatastoresActionCreator = url => dispatch =>
   dispatch({
     type: FETCH_V2V_SOURCE_DATASTORES,
     payload: new Promise((resolve, reject) => {
@@ -32,28 +26,17 @@ const _getSourceDatastoresActionCreator = (url, id) => dispatch => {
           resolve(_filterSourceDatastores(response));
         })
         .catch(e => {
-          if (mockMode) {
-            // to enable UI development without the backend ready, i'm catching the error
-            // and passing some mock data thru the FULFILLED action after the REJECTED action is finished.
-            return dispatch({
-              type: `${FETCH_V2V_SOURCE_DATASTORES}_FULFILLED`,
-              payload: _filterSourceDatastores(
-                requestSourceDatastoresData(id).response
-              )
-            });
-          }
-          return reject(e);
+          reject(e);
         });
     })
   });
-};
 
 export const fetchSourceDatastoresAction = (url, id) => {
   const uri = new URI(`${url}/${id}`);
   // creates url like: http://localhost:3000/api/clusters/1?attributes=storages
   uri.addSearch({ attributes: 'storages' });
 
-  return _getSourceDatastoresActionCreator(uri.toString(), id);
+  return _getSourceDatastoresActionCreator(uri.toString());
 };
 
 const _filterTargetDatastores = response => {
@@ -68,7 +51,7 @@ const _filterTargetDatastores = response => {
   };
 };
 
-const _getTargetDatastoresActionCreator = (url, id) => dispatch => {
+const _getTargetDatastoresActionCreator = url => dispatch =>
   dispatch({
     type: FETCH_V2V_TARGET_DATASTORES,
     payload: new Promise((resolve, reject) => {
@@ -76,25 +59,14 @@ const _getTargetDatastoresActionCreator = (url, id) => dispatch => {
         .then(response => {
           resolve(_filterTargetDatastores(response));
         })
-        .catch(e => {
-          if (mockMode) {
-            return dispatch({
-              type: `${FETCH_V2V_TARGET_DATASTORES}_FULFILLED`,
-              payload: _filterTargetDatastores(
-                requestTargetDatastoresData(id).response
-              )
-            });
-          }
-          return reject(e);
-        });
+        .catch(e => reject(e));
     })
   });
-};
 
 export const fetchTargetDatastoresAction = (url, id) => {
   const uri = new URI(`${url}/${id}`);
   // creates url like: http://localhost:3000/api/clusters/1?attributes=storages
   uri.addSearch({ attributes: 'storages' });
 
-  return _getTargetDatastoresActionCreator(uri.toString(), id);
+  return _getTargetDatastoresActionCreator(uri.toString());
 };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepActions.js
@@ -1,15 +1,9 @@
 import URI from 'urijs';
-import API, { globalMockMode } from '../../../../../../../../common/API';
+import API from '../../../../../../../../common/API';
 import {
   FETCH_V2V_SOURCE_NETWORKS,
   FETCH_V2V_TARGET_NETWORKS
 } from './MappingWizardNetworksStepConstants';
-import {
-  requestSourceNetworksData,
-  requestTargetNetworksData
-} from './mappingWizardNetworksStep.fixtures';
-
-const mockMode = globalMockMode;
 
 const _filterSourceNetworks = response => {
   const { data } = response;
@@ -23,7 +17,7 @@ const _filterSourceNetworks = response => {
   };
 };
 
-const _getSourceNetworksActionCreator = (url, id) => dispatch => {
+const _getSourceNetworksActionCreator = url => dispatch =>
   dispatch({
     type: FETCH_V2V_SOURCE_NETWORKS,
     payload: new Promise((resolve, reject) => {
@@ -32,26 +26,17 @@ const _getSourceNetworksActionCreator = (url, id) => dispatch => {
           resolve(_filterSourceNetworks(response));
         })
         .catch(e => {
-          if (mockMode) {
-            return dispatch({
-              type: `${FETCH_V2V_SOURCE_NETWORKS}_FULFILLED`,
-              payload: _filterSourceNetworks(
-                requestSourceNetworksData(id).response
-              )
-            });
-          }
-          return reject(e);
+          reject(e);
         });
     })
   });
-};
 
 export const fetchSourceNetworksAction = (url, id) => {
   const uri = new URI(`${url}/${id}`);
   // creates url like: http://localhost:3000/api/clusters/1?attributes=lans
   uri.addSearch({ attributes: 'lans' });
 
-  return _getSourceNetworksActionCreator(uri.toString(), id);
+  return _getSourceNetworksActionCreator(uri.toString());
 };
 
 const _filterTargetNetworks = response => {
@@ -66,7 +51,7 @@ const _filterTargetNetworks = response => {
   };
 };
 
-const _getTargetNetworksActionCreator = (url, id) => dispatch => {
+const _getTargetNetworksActionCreator = url => dispatch =>
   dispatch({
     type: FETCH_V2V_TARGET_NETWORKS,
     payload: new Promise((resolve, reject) => {
@@ -75,24 +60,15 @@ const _getTargetNetworksActionCreator = (url, id) => dispatch => {
           resolve(_filterTargetNetworks(response));
         })
         .catch(e => {
-          if (mockMode) {
-            return dispatch({
-              type: `${FETCH_V2V_TARGET_NETWORKS}_FULFILLED`,
-              payload: _filterTargetNetworks(
-                requestTargetNetworksData(id).response
-              )
-            });
-          }
-          return reject(e);
+          reject(e);
         });
     })
   });
-};
 
 export const fetchTargetNetworksAction = (url, id) => {
   const uri = new URI(`${url}/${id}`);
   // creates url like: http://localhost:3000/api/clusters/1?attributes=lans
   uri.addSearch({ attributes: 'lans' });
 
-  return _getTargetNetworksActionCreator(uri.toString(), id);
+  return _getTargetNetworksActionCreator(uri.toString());
 };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardResultsStep/MappingWizardResultsStepActions.js
@@ -1,9 +1,6 @@
-import API, { globalMockMode } from '../../../../../../../../common/API';
+import API from '../../../../../../../../common/API';
 import { POST_V2V_TRANSFORM_MAPPINGS } from './MappingWizardResultsStepConstants';
 import { CONTINUE_TO_PLAN } from '../../../../OverviewConstants';
-import { requestTransformationMappingsData } from './mappingWizardResultsStep.fixtures';
-
-const mockMode = globalMockMode;
 
 export const continueToPlanAction = id => dispatch => {
   dispatch({
@@ -15,7 +12,7 @@ export const continueToPlanAction = id => dispatch => {
 const _postTransformMappingsActionCreator = (
   url,
   transformMappings
-) => dispatch => {
+) => dispatch =>
   dispatch({
     type: POST_V2V_TRANSFORM_MAPPINGS,
     payload: new Promise((resolve, reject) => {
@@ -24,17 +21,10 @@ const _postTransformMappingsActionCreator = (
           resolve(response);
         })
         .catch(e => {
-          if (mockMode) {
-            return dispatch({
-              type: `${POST_V2V_TRANSFORM_MAPPINGS}_FULFILLED`,
-              payload: requestTransformationMappingsData.response
-            });
-          }
-          return reject(e);
+          reject(e);
         });
     })
   });
-};
 
 export const postTransformMappingsAction = (url, transformMappings) =>
   _postTransformMappingsActionCreator(url, transformMappings);

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStepActions.js
@@ -1,14 +1,8 @@
-import API, { globalMockMode } from '../../../../../../../../common/API';
+import API from '../../../../../../../../common/API';
 import {
   POST_V2V_MIGRATION_PLANS,
   POST_V2V_MIGRATION_REQUESTS
 } from './PlanWizardResultsStepConstants';
-import {
-  requestMigrationPlansData,
-  requestMigrationRequestsData
-} from './planWizardResultsStep.fixtures';
-
-const mockMode = globalMockMode;
 
 const postMigrationRequestsAction = (response, dispatch) => {
   dispatch({
@@ -29,51 +23,20 @@ const _postMigrationPlansActionCreator = (
   url,
   migrationPlans,
   planSchedule
-) => dispatch => {
-  if (mockMode) {
-    dispatch({
-      type: POST_V2V_MIGRATION_PLANS,
-      payload: API.post(url, migrationPlans)
-    }).catch(error => {
-      // to enable UI development without the backend ready, i'm catching the error
-      // and passing some mock data thru the FULFILLED action after the REJECTED action is finished.
-      dispatch({
-        type: `${POST_V2V_MIGRATION_PLANS}_FULFILLED`,
-        payload: requestMigrationPlansData.response
-      });
-      if (planSchedule === 'migration_plan_now') {
-        dispatch({
-          type: POST_V2V_MIGRATION_REQUESTS,
-          payload: API.post(
-            `${requestMigrationPlansData.response.data.results[0].href}`,
-            { action: 'order' }
-          ).catch(errorMigrationRequest => {
-            // to enable UI development without the backend ready, i'm catching the error
-            // and passing some mock data thru the FULFILLED action after the REJECTED action is finished.
-            dispatch({
-              type: `${POST_V2V_MIGRATION_REQUESTS}_FULFILLED`,
-              payload: requestMigrationRequestsData.response
-            });
-          })
-        });
-      }
-    });
-  } else {
-    dispatch({
-      type: POST_V2V_MIGRATION_PLANS,
-      payload: new Promise((resolve, reject) => {
-        API.post(url, migrationPlans)
-          .then(response => {
-            resolve(response);
-            if (planSchedule === 'migration_plan_now') {
-              postMigrationRequestsAction(response, dispatch);
-            }
-          })
-          .catch(e => reject(e));
-      })
-    });
-  }
-};
+) => dispatch =>
+  dispatch({
+    type: POST_V2V_MIGRATION_PLANS,
+    payload: new Promise((resolve, reject) => {
+      API.post(url, migrationPlans)
+        .then(response => {
+          resolve(response);
+          if (planSchedule === 'migration_plan_now') {
+            postMigrationRequestsAction(response, dispatch);
+          }
+        })
+        .catch(e => reject(e));
+    })
+  });
 
 export const postMigrationPlansAction = (url, migrationPlans, planSchedule) =>
   _postMigrationPlansActionCreator(url, migrationPlans, planSchedule);

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepActions.js
@@ -1,12 +1,9 @@
 import URI from 'urijs';
-import API, { globalMockMode } from '../../../../../../../../common/API';
+import API from '../../../../../../../../common/API';
 import {
   V2V_VM_STEP_RESET,
   V2V_VALIDATE_VMS
 } from './PlanWizardVMStepConstants';
-import { validateVMsData } from './PlanWizardVMStep.fixtures';
-
-const mockMode = globalMockMode;
 
 const _validateVmsActionCreator = (url, vms) => dispatch => {
   const postBody = {
@@ -21,28 +18,7 @@ const _validateVmsActionCreator = (url, vms) => dispatch => {
           resolve(response);
         })
         .catch(e => {
-          if (mockMode) {
-            let response = null;
-            if (vms && vms.length) {
-              // create a dummy response with the imported csv vms for mock mode testing
-              const dummyVms = vms.map((v, i) => {
-                v.id = v.name + i;
-                return v;
-              });
-              response = {
-                data: {
-                  valid_vms: dummyVms,
-                  invalid_vms: validateVMsData.response.data.invalid_vms,
-                  conflict_vms: validateVMsData.response.data.conflict_vms
-                }
-              };
-            }
-            return dispatch({
-              type: `${V2V_VALIDATE_VMS}_FULFILLED`,
-              payload: response || validateVMsData.response
-            });
-          }
-          return reject(e);
+          reject(e);
         });
     })
   });

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -40,42 +40,40 @@ class Plan extends React.Component {
 
   componentDidMount() {
     const {
-      fetchPlanUrlBuilder,
+      fetchPlanUrl,
       fetchPlanAction,
       planId,
-      fetchPlanRequestUrlBuilder,
+      fetchPlanRequestUrl,
       fetchPlanRequestAction,
       queryPlanVmsAction
     } = this.props;
 
-    fetchPlanAction(fetchPlanUrlBuilder, planId).then(
-      ({ value: { data: plan } }) => {
-        const {
-          miq_requests,
-          options: {
-            config_info: { vm_ids }
-          }
-        } = plan;
-
-        if (miq_requests.length > 0) {
-          const [mostRecentRequest] = miq_requests.slice(-1);
-          const planRequestId = mostRecentRequest.id;
-          fetchPlanRequestAction(fetchPlanRequestUrlBuilder, planRequestId);
-          if (mostRecentRequest.status === 'active') {
-            this.startPolling(planRequestId);
-          } else if (
-            mostRecentRequest.request_state === 'finished' ||
-            mostRecentRequest.status === 'Error'
-          ) {
-            this.setState(() => ({
-              planFinished: true
-            }));
-          }
-        } else {
-          queryPlanVmsAction(vm_ids);
+    fetchPlanAction(fetchPlanUrl, planId).then(({ value: { data: plan } }) => {
+      const {
+        miq_requests,
+        options: {
+          config_info: { vm_ids }
         }
+      } = plan;
+
+      if (miq_requests.length > 0) {
+        const [mostRecentRequest] = miq_requests.slice(-1);
+        const planRequestId = mostRecentRequest.id;
+        fetchPlanRequestAction(fetchPlanRequestUrl, planRequestId);
+        if (mostRecentRequest.status === 'active') {
+          this.startPolling(planRequestId);
+        } else if (
+          mostRecentRequest.request_state === 'finished' ||
+          mostRecentRequest.status === 'Error'
+        ) {
+          this.setState(() => ({
+            planFinished: true
+          }));
+        }
+      } else {
+        queryPlanVmsAction(vm_ids);
       }
-    );
+    });
   }
 
   componentWillUnmount() {
@@ -85,9 +83,9 @@ class Plan extends React.Component {
   }
 
   startPolling(id) {
-    const { fetchPlanRequestAction, fetchPlanRequestUrlBuilder } = this.props;
+    const { fetchPlanRequestAction, fetchPlanRequestUrl } = this.props;
     this.pollingInterval = setInterval(() => {
-      fetchPlanRequestAction(fetchPlanRequestUrlBuilder, id);
+      fetchPlanRequestAction(fetchPlanRequestUrl, id);
     }, 15000);
   }
 
@@ -181,7 +179,7 @@ class Plan extends React.Component {
   }
 }
 Plan.propTypes = {
-  fetchPlanRequestUrlBuilder: PropTypes.func.isRequired,
+  fetchPlanRequestUrl: PropTypes.string.isRequired,
   fetchPlanRequestAction: PropTypes.func.isRequired,
   planName: PropTypes.string,
   planRequestTasks: PropTypes.array,
@@ -189,7 +187,7 @@ Plan.propTypes = {
   isFetchingPlanRequest: PropTypes.bool,
   planRequestPreviouslyFetched: PropTypes.bool,
   errorPlanRequest: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
-  fetchPlanUrlBuilder: PropTypes.func,
+  fetchPlanUrl: PropTypes.string,
   fetchPlanAction: PropTypes.func,
   isFetchingPlan: PropTypes.bool,
   isRejectedPlan: PropTypes.bool,

--- a/app/javascript/react/screens/App/Plan/PlanActions.js
+++ b/app/javascript/react/screens/App/Plan/PlanActions.js
@@ -17,8 +17,9 @@ const _getPlanRequestActionCreator = url => dispatch =>
     payload: API.get(url)
   });
 
-export const fetchPlanRequestAction = (urlBuilder, id) => {
-  const uri = new URI(urlBuilder(id));
+export const fetchPlanRequestAction = (url, id) => {
+  const uri = new URI(`${url}/${id}`);
+  uri.addSearch({ attributes: 'miq_request_tasks' });
   return _getPlanRequestActionCreator(uri.toString());
 };
 
@@ -58,8 +59,9 @@ export const _getPlanActionCreator = url => dispatch =>
     })
   });
 
-export const fetchPlanAction = (urlBuilder, id) => {
-  const uri = new URI(urlBuilder(id));
+export const fetchPlanAction = (url, id) => {
+  const uri = new URI(`${url}/${id}`);
+  uri.addSearch({ attributes: 'miq_requests' });
   return _getPlanActionCreator(uri.toString());
 };
 

--- a/app/javascript/react/screens/App/Plan/PlanActions.js
+++ b/app/javascript/react/screens/App/Plan/PlanActions.js
@@ -1,5 +1,5 @@
 import URI from 'urijs';
-import API, { globalMockMode } from '../../../../common/API';
+import API from '../../../../common/API';
 
 import {
   FETCH_V2V_PLAN_REQUEST,
@@ -8,46 +8,24 @@ import {
   RESET_PLAN_STATE
 } from './PlanConstants';
 
-import { requestPlanData } from './plan.fixtures';
-import { queryVmsData } from './plan.vms.fixtures';
-import { requestPlanRequestData } from './plan.planRequests.fixtures';
-
-const mockMode = globalMockMode;
-
 // *****************************************************************************
 // * FETCH_V2V_PLAN_REQUEST
 // *****************************************************************************
-const _getPlanRequestActionCreator = (url, id) => dispatch => {
-  if (mockMode) {
-    // we don't want to send REJECTED in mock mode here b/c it will reset the state incorrectly
-    dispatch({
-      type: `${FETCH_V2V_PLAN_REQUEST}_FULFILLED`,
-      payload: requestPlanRequestData(id).response
-    });
-  } else {
-    dispatch({
-      type: FETCH_V2V_PLAN_REQUEST,
-      payload: API.get(url)
-    });
-  }
-};
+const _getPlanRequestActionCreator = url => dispatch =>
+  dispatch({
+    type: FETCH_V2V_PLAN_REQUEST,
+    payload: API.get(url)
+  });
 
 export const fetchPlanRequestAction = (urlBuilder, id) => {
   const uri = new URI(urlBuilder(id));
-  return _getPlanRequestActionCreator(uri.toString(), id);
+  return _getPlanRequestActionCreator(uri.toString());
 };
 
 // *****************************************************************************
 // * QUERY_V2V_PLAN_VMS
 // *****************************************************************************
 const _queryPlanVmsActionCreator = ids => dispatch => {
-  if (mockMode) {
-    return dispatch({
-      type: `${QUERY_V2V_PLAN_VMS}_FULFILLED`,
-      payload: queryVmsData.response
-    });
-  }
-
   const resources = ids.map(id => ({
     id
   }));
@@ -66,17 +44,8 @@ export const queryPlanVmsAction = ids => _queryPlanVmsActionCreator(ids);
 // *****************************************************************************
 // * FETCH_V2V_PLAN
 // *****************************************************************************
-export const _getPlanActionCreator = (url, id) => dispatch => {
-  if (mockMode) {
-    return dispatch({
-      type: FETCH_V2V_PLAN,
-      payload: new Promise(resolve => {
-        resolve(requestPlanData(id).response);
-      })
-    });
-  }
-
-  return dispatch({
+export const _getPlanActionCreator = url => dispatch =>
+  dispatch({
     type: FETCH_V2V_PLAN,
     payload: new Promise((resolve, reject) => {
       API.get(url)
@@ -88,11 +57,10 @@ export const _getPlanActionCreator = (url, id) => dispatch => {
         });
     })
   });
-};
 
 export const fetchPlanAction = (urlBuilder, id) => {
   const uri = new URI(urlBuilder(id));
-  return _getPlanActionCreator(uri.toString(), id);
+  return _getPlanActionCreator(uri.toString());
 };
 
 // *****************************************************************************

--- a/app/javascript/react/screens/App/Plan/__test__/PlanActions.test.js
+++ b/app/javascript/react/screens/App/Plan/__test__/PlanActions.test.js
@@ -43,15 +43,9 @@ describe('FETCH_V2V_PLAN', () => {
   });
 
   describe('fetchPlanAction', () => {
-    let urlBuilder;
-    beforeEach(() => {
-      urlBuilder = jest.fn();
-      urlBuilder.mockReturnValueOnce(fetchPlanUrl);
-    });
-
     test('dispatches the PENDING and FULFILLED actions', () => {
       mockRequest(request);
-      return store.dispatch(fetchPlanAction(urlBuilder, id)).then(() => {
+      return store.dispatch(fetchPlanAction(fetchPlanUrl, id)).then(() => {
         expect(store.getActions()).toMatchSnapshot();
       });
     });
@@ -61,7 +55,7 @@ describe('FETCH_V2V_PLAN', () => {
         ...request,
         status: 404
       });
-      return store.dispatch(fetchPlanAction(urlBuilder, id)).catch(() => {
+      return store.dispatch(fetchPlanAction(fetchPlanUrl, id)).catch(() => {
         expect(store.getActions()).toMatchSnapshot();
       });
     });

--- a/app/javascript/react/screens/App/Plan/__test__/__snapshots__/PlanActions.test.js.snap
+++ b/app/javascript/react/screens/App/Plan/__test__/__snapshots__/PlanActions.test.js.snap
@@ -24,7 +24,7 @@ Array [
         "transformResponse": Object {
           "0": [Function],
         },
-        "url": "/api/dummyPlan",
+        "url": "/api/dummyPlan/1?attributes=miq_requests",
         "validateStatus": [Function],
         "xsrfCookieName": "XSRF-TOKEN",
         "xsrfHeaderName": "X-XSRF-TOKEN",


### PR DESCRIPTION
Importing fixtures into our actions files for `mockMode` is bloating our bundle size unnecessarily.  We can hold onto the actual fixture files for tests (I think)

## Before
<img width="743" alt="1__node" src="https://user-images.githubusercontent.com/15141412/39542719-49852012-4e17-11e8-9931-2ecfd0188a60.png">

## After
<img width="729" alt="1__node" src="https://user-images.githubusercontent.com/15141412/39542652-2200b2ae-4e17-11e8-9bf8-e9210d6b1fa8.png">
