### PR TITLE
fix the flicker using a stale prop

### DIFF
--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -21,7 +21,11 @@ class Plan extends React.Component {
       planRequestTasksMutable: Immutable.asMutable(nextProps.planRequestTasks),
       vms: nextProps.vms,
       vmsMutable: Immutable.asMutable(nextProps.vms),
-      planNotStarted: nextProps.planRequestTasks.length === 0
+      planNotStarted:
+        nextProps.plan &&
+        nextProps.plan.miq_requests &&
+        nextProps.plan.miq_requests.length === 0,
+      planRequestPreviouslyFetched: nextProps.planRequestPreviouslyFetched
     };
   }
 
@@ -32,8 +36,11 @@ class Plan extends React.Component {
       planRequestTasksMutable: Immutable.asMutable(props.planRequestTasks),
       vmsMutable: [],
       planNotStarted: false,
-      planFinished: false
+      planFinished: false,
+      planRequestPreviouslyFetched: false
     };
+
+    this.props.resetPlanStateAction();
 
     bindMethods(this, ['stopPolling', 'startPolling']);
   }
@@ -101,7 +108,6 @@ class Plan extends React.Component {
       planName,
       isRejectedPlanRequest,
       isFetchingPlanRequest,
-      planRequestPreviouslyFetched,
       isRejectedPlan,
       isFetchingPlan,
       isQueryingVms,
@@ -112,7 +118,8 @@ class Plan extends React.Component {
       planRequestTasksMutable,
       vmsMutable,
       planNotStarted,
-      planFinished
+      planFinished,
+      planRequestPreviouslyFetched
     } = this.state;
 
     return (
@@ -185,7 +192,7 @@ Plan.propTypes = {
   planRequestTasks: PropTypes.array,
   isRejectedPlanRequest: PropTypes.bool,
   isFetchingPlanRequest: PropTypes.bool,
-  planRequestPreviouslyFetched: PropTypes.bool,
+  planRequestPreviouslyFetched: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
   errorPlanRequest: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
   fetchPlanUrl: PropTypes.string,
   fetchPlanAction: PropTypes.func,

--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -165,7 +165,10 @@ export default (state = initialState, action) => {
         .set('errorVms', action.payload);
 
     case RESET_PLAN_STATE:
-      return state.set('planRequestTasks', []).set('vms', []);
+      return state
+        .set('planRequestTasks', [])
+        .set('vms', [])
+        .set('planRequestPreviouslyFetched', false);
     default:
       return state;
   }


### PR DESCRIPTION
Fixes #266 

* ensures Plan Not Started logic on plan details screen is consistent with overview screen
*  move `planRequestPreviouslyFetched` flag to derived state and reset it to false on load. This ensures that when reloading the detail screen, we initialize that state to false. I would like to revisit this issue next sprint w/ Web Sockets. 