### PR TITLE
fix not started regression

### DIFF
--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -21,10 +21,7 @@ class Plan extends React.Component {
       planRequestTasksMutable: Immutable.asMutable(nextProps.planRequestTasks),
       vms: nextProps.vms,
       vmsMutable: Immutable.asMutable(nextProps.vms),
-      planNotStarted:
-        nextProps.plan &&
-        nextProps.plan.miq_requests &&
-        nextProps.plan.miq_requests.length === 0,
+      planNotStarted: nextProps.planRequestTasks.length === 0,
       planRequestPreviouslyFetched: nextProps.planRequestPreviouslyFetched
     };
   }


### PR DESCRIPTION
The `planNotStarted` in plan detail **should not** have the same logic as plan not started in plan overview (apologies, I just now realized this after fixing the flicker). 

Otherwise, we can't view tasks for Plan Not Started on the Detail.  

cc: @AparnaKarve @michaelkro 

ok to merge?