### PR TITLE
Use fulfilled_on to calculate elapsed time

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
@@ -96,7 +96,7 @@ const MigrationsInProgressCard = ({
   // UX business rule 4: reflect most request recent elapsed time
   const elapsedTime = IsoElpasedTime(
     new Date(mostRecentRequest.created_on),
-    new Date(mostRecentRequest.options.delivered_on)
+    new Date(mostRecentRequest.fulfilled_on)
   );
 
   // Tooltips

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
@@ -96,7 +96,7 @@ const MigrationsInProgressCard = ({
   // UX business rule 4: reflect most request recent elapsed time
   const elapsedTime = IsoElpasedTime(
     new Date(mostRecentRequest.created_on),
-    new Date(mostRecentRequest.fulfilled_on)
+    Date.now()
   );
 
   // Tooltips


### PR DESCRIPTION
It seems that `options.delivered_on` gets set on tasks creation.  Please see
https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_request.rb#L445
can you confirm this @AparnaKarve when you have a moment?

If this is indeed the case, comparing `created_on` with `delivered_on` will not generate the total elapsed time for the Migration in Progress card

Instead, we can compare with `fulfilled_on` (which seems to match `updated_on` for a finished request... not sure which one is best to use here)

The API that we use to refresh the request & request task data is (found [here](https://github.com/priley86/miq_v2v_ui_plugin/blob/alpha/app/javascript/react/screens/App/Overview/OverviewActions.js#L59)).
```js
API.post('/api/requests?expand=resource&attributes=miq_request_tasks', {
          action: 'query',
          resources: allRequests
        })
```
This is a partial snippet of the response returned by that API request
```
{
   "results":[
      {
         "href":"http://localhost:8080/api/requests/165",
         "id":"165",
         "description":"2",
         "approval_state":"approved",
         "type":"ServiceTemplateTransformationPlanRequest",
         "created_on":"2018-05-04T18:17:57Z",
         "updated_on":"2018-05-04T18:18:13Z",
         "fulfilled_on":"2018-05-04T18:18:13Z",
         "requester_id":"1",
         "requester_name":"Administrator",
         "request_type":"transformation_plan",
         "request_state":"finished",
         "message":"VM Transformations failed",
         "status":"Error",
         "options":{
            "dialog":null,
            "workflow_settings":{
               "resource_action_id":"4778"
            },
            "initiator":null,
            "src_id":"103",
            "cart_state":"ordered",
            "requester_group":"EvmGroup-super_administrator",
            "delivered_on":"2018-05-04T18:18:08.387Z"
         }
...
```