### PR TITLE
Fixes notification removal

### DIFF
--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -141,7 +141,6 @@ class Overview extends React.Component {
             id: plan.id
           },
           persistent: !planStatus,
-          timerdelay: planStatus ? 8000 : null,
           actionEnabled: true
         });
       });

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -12,7 +12,7 @@ const MigrationsCompletedList = ({
   redirectTo
 }) => (
   <Grid.Col xs={12}>
-    <Spinner loading={loading}>
+    <Spinner loading={!!loading}>
       {finishedTransformationPlans.length > 0 ? (
         <ListView className="plans-complete-list" style={{ marginTop: 0 }}>
           {finishedTransformationPlans.map(plan => {
@@ -129,7 +129,7 @@ MigrationsCompletedList.propTypes = {
   finishedTransformationPlans: PropTypes.array,
   allRequestsWithTasks: PropTypes.array,
   retryClick: PropTypes.func,
-  loading: PropTypes.bool,
+  loading: PropTypes.string,
   redirectTo: PropTypes.func
 };
 MigrationsCompletedList.defaultProps = {

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -109,7 +109,7 @@ const MigrationsCompletedList = ({
           iconType="pf"
           iconName="info"
           description={
-            <div>
+            <span>
               {__(
                 'There are no existing migration plans in a Completed state.'
               )}
@@ -117,7 +117,7 @@ const MigrationsCompletedList = ({
               {__(
                 'Make a selection in the dropdown to view plans in other states.'
               )}
-            </div>
+            </span>
           }
         />
       )}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCards.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCards.js
@@ -33,7 +33,7 @@ const MigrationsInProgressCards = ({
                 iconType="pf"
                 iconName="info"
                 description={
-                  <div>
+                  <span>
                     {__(
                       'There are no existing migration plans in an In Progress state.'
                     )}
@@ -41,7 +41,7 @@ const MigrationsInProgressCards = ({
                     {__(
                       'Make a selection in the dropdown to view plans in other states.'
                     )}
-                  </div>
+                  </span>
                 }
               />
             )}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -52,7 +52,7 @@ const MigrationsNotStartedList = ({
           iconType="pf"
           iconName="info"
           description={
-            <div>
+            <span>
               {__(
                 'There are no existing migration plans in a Not Started state.'
               )}
@@ -60,7 +60,7 @@ const MigrationsNotStartedList = ({
               {__(
                 'Make a selection in the dropdown to view plans in other states.'
               )}
-            </div>
+            </span>
           }
         />
       )}

--- a/app/javascript/react/screens/App/common/NotificationList/NotificationList.js
+++ b/app/javascript/react/screens/App/common/NotificationList/NotificationList.js
@@ -13,9 +13,9 @@ class NotificationList extends React.Component {
     return (
       <ToastNotificationList>
         {notifications &&
-          notifications.map((notification, index) => (
+          notifications.map(notification => (
             <TimedToastNotification
-              key={index}
+              key={notification.key}
               type={notification.notificationType}
               persistent={notification.persistent}
               timerdelay={notification.timerdelay}

--- a/app/javascript/react/screens/App/common/NotificationList/NotificationListActions.js
+++ b/app/javascript/react/screens/App/common/NotificationList/NotificationListActions.js
@@ -11,7 +11,7 @@ export const addNotificationAction = notification => dispatch => {
     notificationType: notification.notificationType,
     data: notification.data,
     persistent: notification.persistent,
-    timerdelay: notification.timerdelay,
+    timerdelay: notification.timerdelay || 8000,
     actionEnabled: notification.actionEnabled
   });
 };

--- a/app/javascript/react/screens/App/common/NotificationList/NotificationListReducer.js
+++ b/app/javascript/react/screens/App/common/NotificationList/NotificationListReducer.js
@@ -1,4 +1,5 @@
 import Immutable from 'seamless-immutable';
+import uuid from 'uuid/v4';
 
 import {
   V2V_NOTIFICATION_ADD,
@@ -11,6 +12,7 @@ const initialState = Immutable({
 
 export default (state = initialState, action) => {
   const newNotification = {
+    key: uuid(),
     header: action.header,
     message: action.message,
     notificationType: action.notificationType,
@@ -30,8 +32,7 @@ export default (state = initialState, action) => {
       return state.set(
         'notifications',
         Immutable.asMutable(state.notifications).filter(
-          notification =>
-            action.key.notification.message !== notification.message
+          notification => action.key.notification.key !== notification.key
         )
       );
     default:

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "seamless-immutable": "^7.1.2",
     "sortabular": "^1.5.1",
     "table-resolver": "^3.2.0",
-    "urijs": "^1.19.0"
+    "urijs": "^1.19.0",
+    "uuid": "^3.2.1"
   },
   "jest": {
     "setupFiles": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6069,7 +6069,7 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@^3.1.0:
+uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 


### PR DESCRIPTION
fixes #275  (the last commit in the pr does, ends up timed notification do not enjoy null timerdelays)
**OH** its gotta be said, persistent overrides timerdelay, so if something has a timerdelay but `persistent=true` it'll obey the latter. 

When multiple notifications were fired simultaneously, with persisted=false, the last notification would not be removed from the list.  This adds unique ids to each notification, ensuring everything is removed.

### Also fixes migration div enclosed by a p error
<img width="1015" alt="screen shot 2018-05-07 at 12 10 10 pm" src="https://user-images.githubusercontent.com/6640236/39712056-a80ab094-51ef-11e8-9fec-a702a3276cf9.png">


### Also fixes failed invalid prop type errors for migrationcompletedlist card
<img width="1013" alt="screen shot 2018-05-07 at 12 11 04 pm" src="https://user-images.githubusercontent.com/6640236/39712413-f525f784-51f0-11e8-854f-cb06e31cc4a6.png">
