### PR TITLE
Replace `overview` menu-related references with `migration`

### DIFF
--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -3,12 +3,7 @@
 class MigrationController < ApplicationController
   def index
     # this sets the active menu item, must match the item name in lib/miq_v2v_ui/engine.rb
-    @layout = case params[:page]
-              when 'infrastructure-mappings'
-                'infrastructure_mappings'
-              else
-                'overview'
-              end
+    @layout = 'migration'
   end
 
   menu_section :migration

--- a/lib/miq_v2v_ui/engine.rb
+++ b/lib/miq_v2v_ui/engine.rb
@@ -12,7 +12,7 @@ module MiqV2vUI
 
     initializer 'plugin' do
       Menu::CustomLoader.register(
-          Menu::Item.new('overview', N_('Migration'), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration', :default, :compute)
+          Menu::Item.new('migration', N_('Migration'), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration', :default, :compute)
       )
     end
   end


### PR DESCRIPTION
There is no tertiary Menu item for `Overview` anymore.

It is Compute -> Migration now.

Therefore removed all `overview` related references.

<img width="1411" alt="screen shot 2018-05-07 at 11 20 01 am" src="https://user-images.githubusercontent.com/1538216/39717621-b2beda44-51e8-11e8-8a0a-bd7111683041.png">

<img width="1405" alt="screen shot 2018-05-07 at 11 20 18 am" src="https://user-images.githubusercontent.com/1538216/39717625-b5a9cb88-51e8-11e8-848d-2d9c6fd3f010.png">

Fixes #301
https://bugzilla.redhat.com/show_bug.cgi?id=1575613
