### PR TITLE
Use window api methods for correct session timeout

### DIFF
--- a/.jest-setup.js
+++ b/.jest-setup.js
@@ -7,3 +7,4 @@ global.__ = str => str;
 global.n__ = str => str;
 global.sprintf = str => str;
 global.Jed = { sprintf: str => str };
+global.API.get = jest.fn(() => Promise.resolve());

--- a/app/javascript/common/API.js
+++ b/app/javascript/common/API.js
@@ -1,35 +1,31 @@
-import axios from 'axios';
-
-const getAuthToken = () =>
-  localStorage.miq_token ? localStorage.miq_token : '';
-
-axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
-axios.defaults.headers.common['X-Auth-Token'] = getAuthToken();
+const API = window.API; // eslint-disable-line prefer-destructuring
 
 export default {
   get(url, headers = {}, params = {}) {
-    return axios.get(url, {
+    return API.get(url, {
+      transformResponse: e => ({ data: e }),
       headers,
       params
     });
   },
   put(url, data = {}, headers = {}) {
-    return axios.put(url, data, {
+    return API.put(url, data, {
       headers
     });
   },
   post(url, data = {}, headers = {}) {
-    return axios.post(url, data, {
-      headers
+    return API.post(url, data, {
+      headers,
+      transformResponse: e => ({ data: e })
     });
   },
   delete(url, headers = {}) {
-    return axios.delete(url, {
+    return API.delete(url, {
       headers
     });
   },
   patch(url, data = {}, headers = {}) {
-    return axios.patch(url, data, {
+    return API.patch(url, data, {
       headers
     });
   }

--- a/app/javascript/react/screens/App/Overview/__test__/__snapshots__/OverviewActions.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/__test__/__snapshots__/OverviewActions.test.js.snap
@@ -6,47 +6,7 @@ Array [
     "type": "FETCH_V2V_TRANSFORMATION_PLANS_PENDING",
   },
   Object {
-    "payload": Object {
-      "config": Object {
-        "data": undefined,
-        "headers": Object {
-          "Accept": "application/json, text/plain, */*",
-          "X-Auth-Token": "",
-          "X-Requested-With": "XMLHttpRequest",
-        },
-        "maxContentLength": -1,
-        "method": "get",
-        "params": Object {},
-        "timeout": 0,
-        "transformRequest": Object {
-          "0": [Function],
-        },
-        "transformResponse": Object {
-          "0": [Function],
-        },
-        "url": "/api/dummyTransformationPlans",
-        "validateStatus": [Function],
-        "xsrfCookieName": "XSRF-TOKEN",
-        "xsrfHeaderName": "X-XSRF-TOKEN",
-      },
-      "data": null,
-      "headers": undefined,
-      "status": 200,
-    },
     "type": "FETCH_V2V_TRANSFORMATION_PLANS_FULFILLED",
-  },
-]
-`;
-
-exports[`fetchTransformationPlansAction dispatches PENDING and REJECTED actions 1`] = `
-Array [
-  Object {
-    "type": "FETCH_V2V_TRANSFORMATION_PLANS_PENDING",
-  },
-  Object {
-    "error": true,
-    "payload": [Error: Request failed with status code 404],
-    "type": "FETCH_V2V_TRANSFORMATION_PLANS_REJECTED",
   },
 ]
 `;

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/__snapshots__/MappingWizardClusterStepActions.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/__snapshots__/MappingWizardClusterStepActions.test.js.snap
@@ -6,47 +6,7 @@ Array [
     "type": "FETCH_V2V_SOURCE_CLUSTERS_PENDING",
   },
   Object {
-    "payload": Object {
-      "config": Object {
-        "data": undefined,
-        "headers": Object {
-          "Accept": "application/json, text/plain, */*",
-          "X-Auth-Token": "",
-          "X-Requested-With": "XMLHttpRequest",
-        },
-        "maxContentLength": -1,
-        "method": "get",
-        "params": Object {},
-        "timeout": 0,
-        "transformRequest": Object {
-          "0": [Function],
-        },
-        "transformResponse": Object {
-          "0": [Function],
-        },
-        "url": "/api/dummyProviders",
-        "validateStatus": [Function],
-        "xsrfCookieName": "XSRF-TOKEN",
-        "xsrfHeaderName": "X-XSRF-TOKEN",
-      },
-      "data": null,
-      "headers": undefined,
-      "status": 200,
-    },
     "type": "FETCH_V2V_SOURCE_CLUSTERS_FULFILLED",
-  },
-]
-`;
-
-exports[`mappingWizard actions should fetch source clusters and return PENDING and REJECTED action 1`] = `
-Array [
-  Object {
-    "type": "FETCH_V2V_SOURCE_CLUSTERS_PENDING",
-  },
-  Object {
-    "error": true,
-    "payload": [Error: Request failed with status code 404],
-    "type": "FETCH_V2V_SOURCE_CLUSTERS_REJECTED",
   },
 ]
 `;
@@ -57,47 +17,7 @@ Array [
     "type": "FETCH_V2V_TARGET_CLUSTERS_PENDING",
   },
   Object {
-    "payload": Object {
-      "config": Object {
-        "data": undefined,
-        "headers": Object {
-          "Accept": "application/json, text/plain, */*",
-          "X-Auth-Token": "",
-          "X-Requested-With": "XMLHttpRequest",
-        },
-        "maxContentLength": -1,
-        "method": "get",
-        "params": Object {},
-        "timeout": 0,
-        "transformRequest": Object {
-          "0": [Function],
-        },
-        "transformResponse": Object {
-          "0": [Function],
-        },
-        "url": "/api/dummyProviders",
-        "validateStatus": [Function],
-        "xsrfCookieName": "XSRF-TOKEN",
-        "xsrfHeaderName": "X-XSRF-TOKEN",
-      },
-      "data": null,
-      "headers": undefined,
-      "status": 200,
-    },
     "type": "FETCH_V2V_TARGET_CLUSTERS_FULFILLED",
-  },
-]
-`;
-
-exports[`mappingWizard actions should fetch target clusters and return PENDING and REJECTED action 1`] = `
-Array [
-  Object {
-    "type": "FETCH_V2V_TARGET_CLUSTERS_PENDING",
-  },
-  Object {
-    "error": true,
-    "payload": [Error: Request failed with status code 404],
-    "type": "FETCH_V2V_TARGET_CLUSTERS_REJECTED",
   },
 ]
 `;

--- a/app/javascript/react/screens/App/Plan/__test__/__snapshots__/PlanActions.test.js.snap
+++ b/app/javascript/react/screens/App/Plan/__test__/__snapshots__/PlanActions.test.js.snap
@@ -6,47 +6,7 @@ Array [
     "type": "FETCH_V2V_PLAN_PENDING",
   },
   Object {
-    "payload": Object {
-      "config": Object {
-        "data": undefined,
-        "headers": Object {
-          "Accept": "application/json, text/plain, */*",
-          "X-Auth-Token": "",
-          "X-Requested-With": "XMLHttpRequest",
-        },
-        "maxContentLength": -1,
-        "method": "get",
-        "params": Object {},
-        "timeout": 0,
-        "transformRequest": Object {
-          "0": [Function],
-        },
-        "transformResponse": Object {
-          "0": [Function],
-        },
-        "url": "/api/dummyPlan/1?attributes=miq_requests",
-        "validateStatus": [Function],
-        "xsrfCookieName": "XSRF-TOKEN",
-        "xsrfHeaderName": "X-XSRF-TOKEN",
-      },
-      "data": null,
-      "headers": undefined,
-      "status": 200,
-    },
     "type": "FETCH_V2V_PLAN_FULFILLED",
-  },
-]
-`;
-
-exports[`FETCH_V2V_PLAN fetchPlanAction dispatches the PENDING and REJECTED actions 1`] = `
-Array [
-  Object {
-    "type": "FETCH_V2V_PLAN_PENDING",
-  },
-  Object {
-    "error": true,
-    "payload": [Error: Request failed with status code 404],
-    "type": "FETCH_V2V_PLAN_REJECTED",
   },
 ]
 `;

--- a/package.json
+++ b/package.json
@@ -98,6 +98,9 @@
     ],
     "moduleNameMapper": {
       "^.+\\.(png|gif|css|scss)$": "identity-obj-proxy"
+    },
+    "globals": {
+      "API": {}
     }
   },
   "license": "Apache-2.0"


### PR DESCRIPTION
fixes #283
closes https://bugzilla.redhat.com/show_bug.cgi?id=1573547


~So this is the first part of it, but the second part is taking a dip into each reducer and component ensuring each are still getting what they need... Overall, looks that using `window` tools unwraps a layer of abstraction, the `data`.  If feels a little dirty change EACH AND EVERY place that is looking for something along the lines of `actions.payload.data.resources` so gonna keep gnawing on that locally for a bit...~

thanks to the `transformResponse` param done in https://github.com/ManageIQ/manageiq-ui-classic/pull/3662 we're able to make this a REAL short n sweet pr <3