### PR TITLE
Fix the Elapsed time in Completed Migrations list

### DIFF
--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -118,7 +118,7 @@ class Overview extends React.Component {
       freshTransformationPlans.forEach(plan => {
         const mostRecentRequest = plan.miq_requests.reduce(
           (prev, current) =>
-            prev.updated_on > current.updated_on ? prev : current
+            prev.created_on > current.created_on ? prev : current
         );
 
         let planStatusMessage = sprintf(

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -12,6 +12,7 @@ import * as AggregateCards from './components/AggregateCards';
 import InfrastructureMappingsList from './components/InfrastructureMappingsList/InfrastructureMappingsList';
 import Migrations from './components/Migrations/Migrations';
 import componentRegistry from '../../../../components/componentRegistry';
+import getMostRecentRequest from '../common/getMostRecentRequest';
 
 class Overview extends React.Component {
   constructor(props) {
@@ -116,10 +117,7 @@ class Overview extends React.Component {
       );
 
       freshTransformationPlans.forEach(plan => {
-        const mostRecentRequest = plan.miq_requests.reduce(
-          (prev, current) =>
-            prev.created_on > current.created_on ? prev : current
-        );
+        const mostRecentRequest = getMostRecentRequest(plan.miq_requests);
 
         let planStatusMessage = sprintf(
           __('%s completed with errors'),

--- a/app/javascript/react/screens/App/Overview/OverviewSelectors.js
+++ b/app/javascript/react/screens/App/Overview/OverviewSelectors.js
@@ -1,6 +1,6 @@
 const getMostRecentRequest = plan =>
   plan.miq_requests.reduce(
-    (prev, current) => (prev.updated_on > current.updated_on ? prev : current)
+    (prev, current) => (prev.created_on > current.created_on ? prev : current)
   );
 
 export const notStartedTransformationPlansFilter = transformationPlans =>

--- a/app/javascript/react/screens/App/Overview/OverviewSelectors.js
+++ b/app/javascript/react/screens/App/Overview/OverviewSelectors.js
@@ -1,7 +1,4 @@
-const getMostRecentRequest = plan =>
-  plan.miq_requests.reduce(
-    (prev, current) => (prev.created_on > current.created_on ? prev : current)
-  );
+import getMostRecentRequest from '../common/getMostRecentRequest';
 
 export const notStartedTransformationPlansFilter = transformationPlans =>
   transformationPlans.filter(
@@ -14,7 +11,9 @@ export const activeTransformationPlansFilter = (transformationPlans, planId) =>
       return true;
     }
     if (transformationPlan.miq_requests.length > 0) {
-      const mostRecentRequest = getMostRecentRequest(transformationPlan);
+      const mostRecentRequest = getMostRecentRequest(
+        transformationPlan.miq_requests
+      );
       return (
         mostRecentRequest.request_state === 'active' ||
         mostRecentRequest.request_state === 'pending'
@@ -26,7 +25,9 @@ export const activeTransformationPlansFilter = (transformationPlans, planId) =>
 export const finishedTransformationPlansFilter = transformationPlans =>
   transformationPlans.filter(transformationPlan => {
     if (transformationPlan.miq_requests.length > 0) {
-      const mostRecentRequest = getMostRecentRequest(transformationPlan);
+      const mostRecentRequest = getMostRecentRequest(
+        transformationPlan.miq_requests
+      );
       return (
         mostRecentRequest.request_state === 'finished' ||
         mostRecentRequest.request_state === 'failed'

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/ActiveTransformationPlans.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/ActiveTransformationPlans.js
@@ -32,7 +32,7 @@ const ActiveTransformationPlans = ({
         requestsOfAssociatedPlan.length > 0 &&
         requestsOfAssociatedPlan.reduce(
           (prev, current) =>
-            prev.updated_on > current.updated_on ? prev : current
+            prev.created_on > current.created_on ? prev : current
         );
       return (
         mostRecentRequest &&

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/ActiveTransformationPlans.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/ActiveTransformationPlans.js
@@ -10,6 +10,7 @@ import {
   AggregateStatusNotification,
   Spinner
 } from 'patternfly-react';
+import getMostRecentRequest from '../../../../common/getMostRecentRequest';
 
 const ActiveTransformationPlans = ({
   activePlans,
@@ -27,13 +28,9 @@ const ActiveTransformationPlans = ({
       const requestsOfAssociatedPlan = allRequestsWithTasks.filter(
         request => request.source_id === plan.id
       );
-
       const mostRecentRequest =
         requestsOfAssociatedPlan.length > 0 &&
-        requestsOfAssociatedPlan.reduce(
-          (prev, current) =>
-            prev.created_on > current.created_on ? prev : current
-        );
+        getMostRecentRequest(requestsOfAssociatedPlan);
       return (
         mostRecentRequest &&
         mostRecentRequest.miq_request_tasks.some(

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/FinishedTransformationPlans/FinishedTransformationPlans.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/FinishedTransformationPlans/FinishedTransformationPlans.js
@@ -22,7 +22,7 @@ const FinishedTransformationPlans = ({ finishedPlans, loading }) => {
       plan.miq_requests.length > 0 &&
       plan.miq_requests.reduce(
         (prev, current) =>
-          prev.updated_on > current.updated_on ? prev : current
+          prev.created_on > current.created_on ? prev : current
       );
     return mostRecentRequest.status === 'Error';
   });

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/FinishedTransformationPlans/FinishedTransformationPlans.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/FinishedTransformationPlans/FinishedTransformationPlans.js
@@ -10,6 +10,7 @@ import {
   AggregateStatusNotification,
   Spinner
 } from 'patternfly-react';
+import getMostRecentRequest from '../../../../common/getMostRecentRequest';
 
 const FinishedTransformationPlans = ({ finishedPlans, loading }) => {
   const countDescription =
@@ -19,11 +20,7 @@ const FinishedTransformationPlans = ({ finishedPlans, loading }) => {
 
   const failedPlans = finishedPlans.filter(plan => {
     const mostRecentRequest =
-      plan.miq_requests.length > 0 &&
-      plan.miq_requests.reduce(
-        (prev, current) =>
-          prev.created_on > current.created_on ? prev : current
-      );
+      plan.miq_requests.length > 0 && getMostRecentRequest(plan.miq_requests);
     return mostRecentRequest.status === 'Error';
   });
 

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -43,10 +43,10 @@ const MigrationsCompletedList = ({
             });
 
             const elapsedTime = IsoElpasedTime(
-              new Date(mostRecentRequest && mostRecentRequest.created_on),
               new Date(
                 mostRecentRequest && mostRecentRequest.options.delivered_on
-              )
+              ),
+              new Date(mostRecentRequest && mostRecentRequest.fulfilled_on)
             );
 
             return (

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -24,7 +24,7 @@ const MigrationsCompletedList = ({
               requestsOfAssociatedPlan.length > 0 &&
               requestsOfAssociatedPlan.reduce(
                 (prev, current) =>
-                  prev.updated_on > current.updated_on ? prev : current
+                  prev.created_on > current.created_on ? prev : current
               );
 
             const failed =

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { noop, Button, ListView, Grid, Spinner } from 'patternfly-react';
 import { IsoElpasedTime } from '../../../../../../components/dates/IsoElapsedTime';
 import OverviewEmptyState from '../OverviewEmptyState/OverviewEmptyState';
+import getMostRecentRequest from '../../../common/getMostRecentRequest';
 
 const MigrationsCompletedList = ({
   finishedTransformationPlans,
@@ -22,10 +23,7 @@ const MigrationsCompletedList = ({
 
             const mostRecentRequest =
               requestsOfAssociatedPlan.length > 0 &&
-              requestsOfAssociatedPlan.reduce(
-                (prev, current) =>
-                  prev.created_on > current.created_on ? prev : current
-              );
+              getMostRecentRequest(requestsOfAssociatedPlan);
 
             const failed =
               mostRecentRequest && mostRecentRequest.status === 'Error';

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
@@ -12,6 +12,7 @@ import {
   Spinner
 } from 'patternfly-react';
 import { IsoElpasedTime } from '../../../../../../components/dates/IsoElapsedTime';
+import getMostRecentRequest from '../../../common/getMostRecentRequest';
 
 const MigrationsInProgressCard = ({
   plan,
@@ -22,12 +23,9 @@ const MigrationsInProgressCard = ({
   const requestsOfAssociatedPlan = allRequestsWithTasks.filter(
     request => request.source_id === plan.id
   );
-
   const mostRecentRequest =
     requestsOfAssociatedPlan.length > 0 &&
-    requestsOfAssociatedPlan.reduce(
-      (prev, current) => (prev.created_on > current.created_on ? prev : current)
-    );
+    getMostRecentRequest(requestsOfAssociatedPlan);
 
   // if most recent request is still pending, show loading card
   if (

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
@@ -26,7 +26,7 @@ const MigrationsInProgressCard = ({
   const mostRecentRequest =
     requestsOfAssociatedPlan.length > 0 &&
     requestsOfAssociatedPlan.reduce(
-      (prev, current) => (prev.updated_on > current.updated_on ? prev : current)
+      (prev, current) => (prev.created_on > current.created_on ? prev : current)
     );
 
   // if most recent request is still pending, show loading card

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -63,7 +63,7 @@ class Plan extends React.Component {
       if (miq_requests.length > 0) {
         const mostRecentRequest = miq_requests.reduce(
           (prev, current) =>
-            prev.updated_on > current.updated_on ? prev : current
+            prev.created_on > current.created_on ? prev : current
         );
         const planRequestId = mostRecentRequest.id;
         fetchPlanRequestAction(fetchPlanRequestUrl, planRequestId);

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -7,6 +7,7 @@ import Toolbar from '../../../config/Toolbar';
 import PlanRequestDetailList from './components/PlanRequestDetailList/PlanRequestDetailList';
 import PlanVmsList from './components/PlanVmsList';
 import PlanEmptyState from './components/PlanEmptyState';
+import getMostRecentRequest from '../common/getMostRecentRequest';
 
 class Plan extends React.Component {
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -61,10 +62,7 @@ class Plan extends React.Component {
       } = plan;
 
       if (miq_requests.length > 0) {
-        const mostRecentRequest = miq_requests.reduce(
-          (prev, current) =>
-            prev.created_on > current.created_on ? prev : current
-        );
+        const mostRecentRequest = getMostRecentRequest(miq_requests);
         const planRequestId = mostRecentRequest.id;
         fetchPlanRequestAction(fetchPlanRequestUrl, planRequestId);
         if (mostRecentRequest.status === 'active') {

--- a/app/javascript/react/screens/App/common/getMostRecentRequest.js
+++ b/app/javascript/react/screens/App/common/getMostRecentRequest.js
@@ -1,0 +1,6 @@
+const getMostRecentRequest = requests =>
+  requests.reduce(
+    (prev, current) => (prev.created_on > current.created_on ? prev : current)
+  );
+
+export default getMostRecentRequest;


### PR DESCRIPTION
- Fixed the Elapsed time in Completed Migrations list

Before -
<img width="1403" alt="screen shot 2018-05-11 at 11 34 24 am" src="https://user-images.githubusercontent.com/1538216/39940806-4ef8db20-550f-11e8-8d3c-a009b217e828.png">

After -
<img width="1411" alt="screen shot 2018-05-11 at 11 33 04 am" src="https://user-images.githubusercontent.com/1538216/39940826-61f3a20a-550f-11e8-97d5-da5941a498cc.png">


The second commit dbe87b6 is about an adjustment to the `mostRecentRequest` calculation based on a technicality (explained in the commit message)
