### PR TITLE
Add Conversion host to popover for a VM in a Migration Plan

### DIFF
--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -401,6 +401,10 @@ class PlanRequestDetailList extends React.Component {
                       <b>{__('Description')}: </b>
                       {task.options.progress.current_description}
                     </div>
+                    <div>
+                      <b>{__('Conversion Host')}: </b>
+                      {task.options.transformation_host_name}
+                    </div>
                     {task.taskCompleted && (
                       <div>
                         <br />


### PR DESCRIPTION
I am rebuilding my rails environment on latest alpha... This should work, though.  All that trouble for 4 lines of JSX. Sorry guys.